### PR TITLE
TOOLS-2556 API documentation should reflect new ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@
 
 <!--
     Copyright 2019 Joyent, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # Manta Contribution Guidelines
 
 Thanks for using Manta and for considering contributing to it!
 
-
-# Code
+## Code
 
 All changes to Manta project repositories go through code review via a GitHub
 pull request.
@@ -26,8 +26,8 @@ mailing list or IRC](README.md#community).
 See the (work-in-progress) [developer guide](docs/dev-notes.md) for useful
 information about building and testing the software.
 
-Manta repositories use the same [Joyent Engineering
-Guidelines](https://github.com/joyent/eng/blob/master/docs/index.md) as
+Manta repositories use the same [Triton Engineering
+Guidelines](https://github.com/TritonDataCenter/eng/blob/master/docs/index.md) as
 the Triton project.  Notably:
 
 * The #master branch should be first-customer-ship (FCS) quality at all times.
@@ -38,20 +38,19 @@ the Triton project.  Notably:
 Typically each repository has `make check` to lint and check code style.
 Specific code style can vary by repository.
 
-
-## Issues
+### Issues
 
 There are two separate issue trackers that are relevant for Manta code:
 
-- An internal-to-Joyent JIRA instance.
+* An private JIRA instance.
 
   A JIRA ticket has an ID like `MANTA-380`, where "MANTA" is the JIRA project
   name. A read-only view of many JIRA tickets is made available at
   <https://smartos.org/bugview/> (e.g.
   <https://smartos.org/bugview/MANTA-380>).
 
-- GitHub issues for the relevant repository.
+* GitHub issues for the relevant repository.
 
 Before Manta was open sourced, Joyent engineering used a private JIRA instance.
-While Joyent continues to use JIRA internally, we also use GitHub issues for
+While we continue to use JIRA internally, we also use GitHub issues for
 tracking -- primarily to allow interaction with those without access to JIRA.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <!--
     Copyright 2019 Joyent, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # Manta: Triton's object storage and converged analytics solution
@@ -23,10 +24,10 @@ store).  The intended use-cases are wide-ranging:
 * data warehousing
 * software crash dump storage and analysis
 
-Joyent operates a public-facing production [Manta
-service](https://www.joyent.com/products/manta), but all the pieces required to
-deploy and operate your own Manta are open source.  This repo provides
-documentation for the overall Manta project and pointers to the other
+MNX operates a public-facing production [Manta
+service](https://www.tritondatacenter.com/products/manta), but all the pieces
+required to deploy and operate your own Manta are open source.  This repo
+provides documentation for the overall Manta project and pointers to the other
 repositories that make up a complete Manta deployment.
 
 ## Getting started
@@ -34,26 +35,29 @@ repositories that make up a complete Manta deployment.
 The fastest way to get started with Manta depends on what exactly one
 wishes to do.
 
-* To experiment with Manta, the fastest way is to start playing with [Joyent's
-Manta service](https://www.joyent.com/products/manta); see the [Getting
-Started](https://apidocs.joyent.com/manta/index.html#getting-started) guide in
-the user documentation for details.
+* To experiment with Manta, the fastest way is to start playing with [MNX's
+Manta service](https://www.tritondatacenter.com/products/manta); see the [Getting
+Started](https://apidocs.tritondatacenter.com/manta/index.html#getting-started)
+guide in the user documentation for details.
 
-* To see a detailed, real example of using Manta, check out [Kartlytics: Applying Big Data Analytics to Mario Kart](http://www.joyent.com/blog/introducing-kartlytics-mario-kart-64-analytics).
+* To see a detailed, real example of using Manta, check out
+[Kartlytics: Applying Big Data Analytics to Mario Kart](https://www.tritondatacenter.com/blog/introducing-kartlytics-mario-kart-64-analytics).
 
 * To learn about installing and operating your own Manta deployment, see the
-[Manta Operator's Guide](https://joyent.github.io/manta/).
+[Manta Operator's Guide](https://TritonDataCenter.github.io/manta/).
 
 * To understand Manta's architecture, see
 [Bringing Arbitrary Compute to Authoritative
-Data](http://queue.acm.org/detail.cfm?id=2645649), the
-[ACM Queue](http://queue.acm.org/)
+Data](https://queue.acm.org/detail.cfm?id=2645649), the
+[ACM Queue](https://queue.acm.org/)
 article on its design and implementation.
 
 * To understand the
-[CAP tradeoffs](http://en.wikipedia.org/wiki/CAP_theorem) in Manta,
+[CAP tradeoffs](https://en.wikipedia.org/wiki/CAP_theorem) in Manta,
 see [Dave Pacheco](https://github.com/davepacheco)'s blog entry on
-[Fault Tolerence in Manta](http://dtrace.org/blogs/dap/2013/07/03/fault-tolerance-in-manta/) -- which, it must be said, received [the highest possible praise](https://twitter.com/eric_brewer/status/352804538769604609).
+[Fault Tolerence in Manta](https://dtrace.org/blogs/dap/2013/07/03/fault-tolerance-in-manta/)
+-- which, it must be said, received
+[the highest possible praise](https://twitter.com/eric_brewer/status/352804538769604609).
 
 * For help with working on Manta and building and testing your changes,
   see the [developer notes](docs/dev-notes.md)
@@ -75,19 +79,18 @@ Twitter for updates.
 
 ## Dependencies
 
-Manta is deployed on top of Joyent's
-[Triton DataCenter](https://github.com/joyent/triton) platform (just "Triton"
-for short), which is also open-source. Triton provides services for operating
-physical servers (compute nodes), deploying services in containers, monitoring
-services, transmitting and visualizing real-time performance data, and a bunch
-more. Manta primarily uses Triton for initial deployment, service upgrade, and
-service monitoring.
+Manta is deployed on top of
+[Triton DataCenter](https://github.com/TritonDataCenter/triton) platform (just
+"Triton" for short), which is also open-source. Triton provides services for
+operating physical servers (compute nodes), deploying services in containers,
+monitoring services, transmitting and visualizing real-time performance data,
+and a bunch more. Manta primarily uses Triton for initial deployment, service
+upgrade, and service monitoring.
 
-Triton itself depends on [SmartOS](http://smartos.org).  Manta also directly
+Triton itself depends on [SmartOS](https://smartos.org).  Manta also directly
 depends on several SmartOS features, notably: ZFS pooled storage, ZFS rollback,
 and
-[hyprlofs](https://github.com/joyent/illumos-joyent/blob/master/usr/src/uts/common/fs/hyprlofs/hyprlofs_vfsops.c).
-
+[hyprlofs](https://github.com/TritonDataCenter/illumos-joyent/blob/master/usr/src/uts/common/fs/hyprlofs/hyprlofs_vfsops.c).
 
 ## Building and Deploying Manta
 
@@ -95,19 +98,18 @@ Manta is built and packaged with Triton DataCenter. Building the raw pieces uses
 the same mechanisms as building the services that are part of Triton. When you
 build a Triton headnode image (which is the end result of the whole Triton build
 process), one of the built-in services you get is a [Manta
-deployment](http://github.com/joyent/sdc-manta) service, which is used
-to bootstrap a Manta installation.
+deployment](https://github.com/TritonDataCenter/sdc-manta) service, which is
+used to bootstrap a Manta installation.
 
 Once you have Triton set up, follow the instructions in the
 [Manta Operator's
-Guide](https://joyent.github.io/manta/)
+Guide](https://TritonDataCenter.github.io/manta/)
 to deploy Manta.  The easiest way to play around with your own Manta
 installation is to first set up a Triton cloud-on-a-laptop (COAL) installation
 in VMware and then follow those instructions to deploy Manta on it.
 
 If you want to deploy your own builds of Manta components, see "Deploying your
 own Manta Builds" below.
-
 
 ## Repositories
 
@@ -116,31 +118,33 @@ is actually made up of several components stored in other repos.
 
 The front door services respond to requests from the internet at large:
 
-* [muppet](https://github.com/joyent/muppet): haproxy + stud-based SSL
+* [muppet](https://github.com/TritonDataCenter/muppet): haproxy + stud-based SSL
   terminator and loadbalancer
-* [muskie](https://github.com/joyent/manta-muskie): Node-based API server
-* [mahi](https://github.com/joyent/mahi): authentication cache
-* [medusa](https://github.com/joyent/manta-medusa): handles interactive (mlogin)
-  sessions
+* [muskie](https://github.com/TritonDataCenter/manta-muskie): Node-based API
+  server
+* [mahi](https://github.com/TritonDataCenter/mahi): authentication cache
+* [medusa](https://github.com/TritonDataCenter/manta-medusa): handles
+  interactive (mlogin) sessions
 
 The metadata tier stores the entire object namespace (not object data) as well
 as information about compute jobs and backend storage system capacity:
 
-* [manatee](https://github.com/joyent/manatee): high-availability postgres
-  cluster using synchronous replication and automatic fail-over
-* [moray](https://github.com/joyent/moray): Node-based key-value store built on
-  top of manatee.  Also responsible for monitoring manatee replication topology
-  (i.e., which postgres instance is the master).
-* [electric-moray](https://github.com/joyent/electric-moray): Node-based service
-  that provides the same interface as Moray, but which directs requests to one
-  or more Moray+Manatee *shards* based on hashing the Moray key.
+* [manatee](https://github.com/TritonDataCenter/manatee): high-availability
+  postgres cluster using synchronous replication and automatic fail-over
+* [moray](https://github.com/TritonDataCenter/moray): Node-based key-value
+  store built on top of manatee.  Also responsible for monitoring manatee
+  replication topology (i.e., which postgres instance is the master).
+* [electric-moray](https://github.com/TritonDataCenter/electric-moray):
+  Node-based service that provides the same interface as Moray, but which
+  directs requests to one or more Moray+Manatee *shards* based on hashing the
+  Moray key.
 
 The storage tier is responsible for actually storing bits on disk:
 
-* [mako](https://github.com/joyent/manta-mako): nginx-based server that receives
-  PUT/GET requests from Muskie to store object data on disk.
+* [mako](https://github.com/TritonDataCenter/manta-mako): nginx-based server
+  that receives PUT/GET requests from Muskie to store object data on disk.
 
-The compute tier (also called [Marlin](https://github.com/joyent/manta-marlin))
+The compute tier (also called [Marlin](https://github.com/TritonDataCenter/manta-marlin))
 is responsible for the distributed execution of user jobs.  Most of it is
 contained in the Marlin repo, and it consists of:
 
@@ -151,30 +155,32 @@ contained in the Marlin repo, and it consists of:
 * lackey: a Node-based service that runs inside each compute zone under the
   direction of the marlin agent.  The lackey is responsible for actually
   executing individual user tasks inside compute containers.
-* [wrasse](https://github.com/joyent/manta-wrasse): job archiver and purger,
-  which removes job information from moray after the job completes and saves
-  the lists of inputs, outputs, and errors back to Manta for user reference
+* [wrasse](https://github.com/TritonDataCenter/manta-wrasse): job archiver and
+  purger, which removes job information from moray after the job completes and
+  saves the lists of inputs, outputs, and errors back to Manta for user
+  reference
 
 There are a number of services not part of the data path that are critical for
 Manta's operation:
 
-* [binder](https://github.com/joyent/binder): hosts both ZooKeeper (used for
-  manatee leader election and for group membership) and a Node-based DNS server
-  that keeps track of which instances of each service are online at any given
-  time
-* [mola](https://github.com/joyent/manta-mola): garbage collection (removing
-  files from storage servers corresponding to objects that have been deleted
-  from the namespace) and audit (verifying that objects in the index tier
-  exist on the storage hosts)
-* [mackerel](https://github.com/joyent/manta-mackerel): metering (computing
-  per-user details about requests made, bandwidth used, storage used, and
-  compute time used)
-* [madtom](https://github.com/joyent/manta-madtom): real-time "is-it-up?"
-  dashboard, showing the status of all services deployed
-* [marlin-dashboard](https://github.com/joyent/manta-marlin-dashboard):
+* [binder](https://github.com/TritonDataCenter/binder): hosts both ZooKeeper
+  (used for manatee leader election and for group membership) and a Node-based
+  DNS server that keeps track of which instances of each service are online at
+  any given time
+* [mola](https://github.com/TritonDataCenter/manta-mola): garbage collection
+  (removing files from storage servers corresponding to objects that have been
+  deleted from the namespace) and audit (verifying that objects in the index
+  tier exist on the storage hosts)
+* [mackerel](https://github.com/TritonDataCenter/manta-mackerel): metering
+  (computing per-user details about requests made, bandwidth used, storage used,
+  and compute time used)
+* [madtom](https://github.com/TritonDataCenter/manta-madtom): real-time
+  "is-it-up?" dashboard, showing the status of all services deployed
+* [marlin-dashboard](https://github.com/TritonDataCenter/manta-marlin-dashboard):
   real-time dashboard showing detaild status for the compute tier
-* [minnow](https://github.com/joyent/manta-minnow): a Node-based service that
-  runs inside mako zones to periodically report storage capacity into Moray
+* [minnow](https://github.com/TritonDataCenter/manta-minnow): a Node-based
+  service that runs inside mako zones to periodically report storage capacity
+  into Moray
 
 With the exception of the Marlin agent and lackey, each of the above components
 are *services*, of which there may be multiple *instances* in a single Manta
@@ -183,31 +189,30 @@ all be deployed redundantly for availability and additional instances can be
 deployed to increase capacity.
 
 Finally, scripts used to set up these component zones live in the
-[https://github.com/joyent/manta-scripts](manta-scripts) repo.
+[https://github.com/TritonDataCenter/manta-scripts](manta-scripts) repo.
 
 For more details on the architecture, including how these pieces actually fit
 together, see "Architecture Basics" in the
 [Manta Operator's
-Guide](https://joyent.github.io/manta/).
-
+Guide](https://TritonDataCenter.github.io/manta/).
 
 ## Deploying your own Manta Builds
 
 As described above, as part of the normal Manta deployment process, you start
 with the "manta-deployment" zone that's built into Triton.  Inside that zone, you
-run "manta-init" to fetch the latest Joyent build of each Manta component.  Then
+run "manta-init" to fetch the latest build of each Manta component.  Then
 you run Manta deployment tools to actually deploy zones based on these builds.
 
 The easiest way to use your own custom build is to first deploy Manta using the
-default Joyent build and *then* replace whatever components you want with your
-own builds.  This will also ensure that you're starting from a known-working set
+default build and *then* replace whatever components you want with your own
+builds.  This will also ensure that you're starting from a known-working set
 of builds so that if something goes wrong, you know where to start looking.  To
 do this:
 
 1. Complete the Manta deployment procedure from the [Manta Operator's
-Guide](https://joyent.github.io/manta/).
+Guide](https://TritonDataCenter.github.io/manta/).
 1. Build a zone image for whatever zone you want to replace.  See the
-   instructions for building [Triton](https://github.com/joyent/triton)
+   instructions for building [Triton](https://github.com/TritonDataCenter/triton)
    zone images.  Manta zones work the same way.  The output of this process
    will be a zone **image**, identified by uuid.  The image is comprised of
    two files: an image manifest (a JSON file) and the image file itself
@@ -225,23 +230,23 @@ Guide](https://joyent.github.io/manta/).
            sdc-imgadm import -m /var/tmp/my_manifest.json -f /var/tmp/my_image
 
 1. Now you can use the normal Manta zone update procedure (from the [Manta
-   Operator's Guide](https://joyent.github.io/manta/).
+   Operator's Guide](https://TritonDataCenter.github.io/manta/).
    This involves saving the current configuration to a JSON
    file using "manta-adm show -sj > config.json", updating the configuration
    file, and then applying the changes with "manta-adm update < config.json".
    When you modify the configuration file, you can use your image's uuid in
    place of whatever service you're trying to replace.
 
-If for some reason you want to avoid deploying the Joyent builds at all, you'll
+If for some reason you want to avoid deploying provided builds at all, you'll
 have to follow a more manual procedure.  One approach is to update the SAPI
 configuration for whatever service you want (using sdc-sapi -- see
-[SAPI](https://github.com/joyent/sdc-sapi)) *immediately after* running
+[SAPI](https://github.com/TritonDataCenter/sdc-sapi)) *immediately after* running
 manta-init but before deploying anything.  Note that each subsequent
 "manta-init" will clobber this change, though the SAPI configuration is normally
 only used for the initial deployment anyway.  The other option is to apply the
 fully-manual install procedure from the
 [Manta Operator's
-Guide](https://joyent.github.io/manta/)
+Guide](https://TritonDataCenter.github.io/manta/)
 (i.e., instead of
 using manta-deploy-coal or manta-deploy-lab) and use a custom "manta-adm"
 configuration file in the first place.  If this is an important use case, file
@@ -251,19 +256,17 @@ The above procedure works to update Manta *zones*, which are most of the
 components above.  The other two kinds of components are the *platform* and
 *agents*.  Both of these procedures are documented in the
 [Manta Operator's
-Guide](https://joyent.github.io/manta/), and they work to deploy custom builds as well as the official Joyent
-builds.
-
+Guide](https://TritonDataCenter.github.io/manta/), and they work to deploy
+custom builds as well as the official builds.
 
 ## Contributing to Manta
 
 To report bugs or request features, you can submit issues to the Manta project
-on Github.  If you're asking for help with Joyent's production Manta service,
-you should contact Joyent support instead.
+on Github.  If you're asking for help with MNX's production Manta service,
+you should contact MNX support instead.
 
 See the [Contribution Guidelines](CONTRIBUTING.md) for information about
 contributing changes to the project.
-
 
 ## Design principles
 
@@ -280,7 +283,7 @@ Manta assumes several constraints on the data storage problem:
    special-purpose interfaces for use-cases like log analysis or video
    transcoding.)
 1. The system should be strongly consistent and highly available.  In terms of
-   [CAP](http://en.wikipedia.org/wiki/CAP_theorem), Manta sacrifices
+   [CAP](https://en.wikipedia.org/wiki/CAP_theorem), Manta sacrifices
    availability in the face of network partitions.  (The reasoning here is that
    an AP cache can be built atop a CP system like Manta, but if Manta were AP,
    then it would be impossible for anyone to get CP semantics.)
@@ -347,24 +350,24 @@ Compute to Authoritative Data".
 
 For background on the problem space and design principles, check out ["Bringing
 Arbitrary Compute to Authoritative
-Data"](http://queue.acm.org/detail.cfm?id=2645649).
+Data"](https://queue.acm.org/detail.cfm?id=2645649).
 
 For background on the overall design approach, see ["There's Just No Getting
 Around It: You're Building a Distributed
-System"](http://queue.acm.org/detail.cfm?id=2482856).
+System"](https://queue.acm.org/detail.cfm?id=2482856).
 
 For information about how Manta is designed to survive component failures and
 maintain strong consistency, see [Fault tolerance in
-Manta](http://dtrace.org/blogs/dap/2013/07/03/fault-tolerance-in-manta/).
+Manta](https://dtrace.org/blogs/dap/2013/07/03/fault-tolerance-in-manta/).
 
-For information on the latest recommended production hardware, see [Joyent
-Manufacturing Matrix](http://eng.joyent.com/manufacturing/matrix.html) and
-[Joyent Manufacturing Bill of
-Materials](http://eng.joyent.com/manufacturing/bom.html).
+For information on the latest recommended production hardware, see [Triton
+Manufacturing Matrix](https://eng.tritondatacenter.com/manufacturing/matrix.html) and
+[Triton Manufacturing Bill of
+Materials](https://eng.tritondatacenter.com/manufacturing/bom.html).
 
 Applications and customer stories:
 
 * [Kartlytics: Applying Big Data Analytics to Mario
-  Kart](http://www.joyent.com/blog/introducing-kartlytics-mario-kart-64-analytics)
+  Kart](https://www.tritondatacenter.com/blog/introducing-kartlytics-mario-kart-64-analytics)
 * [A Cost-effective Approach to Scaling Event-based Data Collection and
-  Analysis](http://building.wanelo.com/2013/06/28/a-cost-effective-approach-to-scaling-event-based-data-collection-and-analysis.html)
+  Analysis](https://building.wanelo.com/2013/06/28/a-cost-effective-approach-to-scaling-event-based-data-collection-and-analysis.html)

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -6,6 +6,7 @@
 
 <!--
     Copyright 2019 Joyent, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # Manta developer notes
@@ -37,7 +38,7 @@ works like this:
 1. Build the repository itself.
 2. Build an image (a zone filesystem template and some metadata) from the
    contents of the built repository.
-3. Optionally, publish the image to updates.joyent.com.
+3. Optionally, publish the image to updates.tritondatacenter.com.
 4. Import the image into a Triton instance.
 5. Provision a new zone from the imported image.
 6. During the first boot, the zone executes a one-time setup script.
@@ -51,14 +52,14 @@ There are tools to automate most of this:
   which assembles an image containing the built Manta component.  The image
   represents a template filesystem with which instances of this
   component will be stamped out.  After the image is built, it can be uploaded
-  to updates.joyent.com. Alternatively, the image can be manually imported to
-  a Triton instance by copying the image manifest and image file
+  to updates.tritondatacenter.com. Alternatively, the image can be manually
+  imported to a Triton instance by copying the image manifest and image file
   (a compressed zfs send stream) to the headnode and running
-  "sdc-imgadm import".
+  `sdc-imgadm import`.
 * The "manta-init" command takes care of step 4.  You run this as part of any
-  deployment.  See the [Manta Operator's Guide](https://joyent.github.io/manta)
+  deployment.  See the [Manta Operator's Guide](https://TritonDataCenter.github.io/manta)
   for details.  After the first run, subsequent runs find new images in
-  updates.joyent.com, import them into the current Triton instance, and mark
+  updates.tritondatacenter.com, import them into the current Triton instance, and mark
   them for use by "manta-deploy". Alternatively, if you have images that were
   manually imported using "sdc-imgadm import", then "manta-init" can be run
   with the "-n" flag to use those local images instead.
@@ -68,8 +69,7 @@ There are tools to automate most of this:
   previous steps.
 
 For more information on the zone setup and boot process, see the
-[manta-scripts](https://github.com/joyent/manta-scripts) repo.
-
+[manta-scripts](https://github.com/TritonDataCenter/manta-scripts) repo.
 
 ## Testing changes inside an actual Manta deployment
 
@@ -111,7 +111,7 @@ which is that most components are delivered as zone images and deployed by
 provisioning new zones from these images.  While the deployment tools are
 slightly different than Triton's, the build process is nearly identical.  The
 common instructions for building zone images are part of the [Triton
-documentation](https://github.com/joyent/triton/blob/master/docs/developer-guide/building.md).
+documentation](https://github.com/TritonDataCenter/triton/blob/master/docs/developer-guide/building.md).
 
 ### Building with your changes
 
@@ -119,10 +119,10 @@ Building a repository checked out to a given git branch will include those
 changes in the resulting image.
 
 One exception, is any `agents` (for example
-[`amon`](https://github.com/joyent/sdc-amon),
-[`config-agent`](https://github.com/joyent/sdc-config-agent/),
-[`registrar`](https://github.com/joyent/registrar), (there are others)) that
-are bundled within the image.
+[`amon`](https://github.com/TritonDataCenter/sdc-amon),
+[`config-agent`](https://github.com/TritonDataCenter/sdc-config-agent/),
+[`registrar`](https://github.com/TritonDataCenter/registrar), etc.)
+that are bundled within the image.
 
 At build-time, the build will attempt to build agents from the same branch
 name as the checked-out branch of the component being built. If that branch
@@ -137,10 +137,10 @@ branch name as the checked-out branch of the component you're building, before
 finally falling back to the `master` branch of that agent repository.
 
 The mechanism used is described in the
-[`Makefile.agent_prebuilt.defs`](https://github.com/joyent/eng/blob/master/tools/mk/Makefile.agent_prebuilt.defs),
-[`Makefile.agent_prebuilt.targ`](https://github.com/joyent/eng/blob/master/tools/mk/Makefile.agent_prebuilt.targ),
+[`Makefile.agent_prebuilt.defs`](https://github.com/TritonDataCenter/eng/blob/master/tools/mk/Makefile.agent_prebuilt.defs),
+[`Makefile.agent_prebuilt.targ`](https://github.com/TritonDataCenter/eng/blob/master/tools/mk/Makefile.agent_prebuilt.targ),
 and
-[`agent-prebuilt.sh`](https://github.com/joyent/eng/blob/master/tools/agent_prebuilt.sh)
+[`agent-prebuilt.sh`](https://github.com/TritonDataCenter/eng/blob/master/tools/agent_prebuilt.sh)
 files, likely appearing as a git submodule beneath `deps/eng` in the
 component repository.
 
@@ -150,9 +150,9 @@ In some cases, you may be testing a change to a single zone that involves more
 than one repository.  For example, you may need to change not just madtom, but
 the node-checker module on which it depends.  One way to test this is to push
 your dependency changes to a personal github clone (e.g.,
-"davepacheco/node-checker" rather than "joyent/node-checker") and then commit a
-change to your local copy of the zone's repo ("manta-madtom", in this case) that
-points the repo at your local dependency:
+"davepacheco/node-checker" rather than "TritonDataCenter/node-checker") and then
+commit a change to your local copy of the zone's repo ("manta-madtom", in this
+case) that points the repo at your local dependency:
 
     diff --git a/package.json b/package.json
     index a054b43..8ef5a35 100644
@@ -162,9 +162,9 @@ points the repo at your local dependency:
              "dependencies": {
                      "assert-plus": "0.1.1",
                      "bunyan": "0.16.6",
-    -                "checker": "git://github.com/joyent/node-checker#master",
+    -                "checker": "git://github.com/TritonDataCenter/node-checker#master",
     +                "checker": "git://github.com/davepacheco/node-checker#master",
-                     "moray": "git://github.com/joyent/node-moray.git#master",
+                     "moray": "git://github.com/TritonDataCenter/node-moray.git#master",
                      "posix-getopt": "1.0.0",
                      "pg": "0.11.3",
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -6,6 +6,7 @@
 
 <!--
     Copyright 2020 Joyent, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # Manta v1 Operator Guide
@@ -23,21 +24,21 @@ first class operation. The user interface to Manta is essentially:
 * Users submit map-reduce *compute jobs* that run arbitrary Unix programs on
   their objects.
 
-Users can interact with Manta through the official Node.js CLI; the Joyent user
+Users can interact with Manta through the official Node.js CLI; the Triton user
 portal; the Node, Python, Ruby, or Java SDKs; curl(1); or any web browser.
 
 For more information, see the official [public user
-documentation](http://apidocs.joyent.com/manta/).  **Before reading this
+documentation](http://apidocs.tritondatacenter.com/manta/).  **Before reading this
 document, you should be very familiar with using Manta, including both the CLI
 tools and the compute jobs features. You should also be comfortable with all the
-[reference material](http://apidocs.joyent.com/manta/) on how the system works
+[reference material](http://apidocs.tritondatacenter.com/manta/) on how the system works
 from a user's perspective.**
 
 *(Note: This is the operator guide for Manta v1. See [this
-document](https://github.com/joyent/manta/blob/master/docs/mantav2.md) for
+document](https://github.com/TritonDataCenter/manta/blob/master/docs/mantav2.md) for
 information on mantav1 vs mantav2. If you are using mantav2, please see the
 [Mantav2 Operator
-Guide](https://github.com/joyent/manta/blob/master/docs/operator-guide.md).)*
+Guide](https://github.com/TritonDataCenter/manta/blob/master/docs/operator-guide.md).)*
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -270,7 +271,7 @@ In order to make all this work, there are several other pieces:
   servers that actually handle user HTTP requests.  All user interaction with
   Manta happens over HTTP (even compute jobs), so the front door handles all
   user-facing operations.
-* An **authentication cache** maintains a read-only copy of the Joyent account
+* An **authentication cache** maintains a read-only copy of the UFDS account
   database.  All front door requests are authenticated against this cache.
 * A **garbage collection and auditing** system periodically compares the
   contents of the metadata tier with the contents of the storage tier to
@@ -311,22 +312,22 @@ services.
 
 | Kind    | Major subsystem | Service          | Purpose                               | Components                                                                                             |
 | ------- | --------------- | ---------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Service | Consensus       | nameservice      | Service discovery                     | ZooKeeper, [binder](https://github.com/joyent/binder) (DNS)                                            |
-| Service | Front door      | loadbalancer     | SSL termination and load balancing    | stud, haproxy/[muppet](https://github.com/joyent/muppet)                                               |
-| Service | Front door      | webapi           | Manta HTTP API server                 | [muskie](https://github.com/joyent/manta-muskie)                                                       |
-| Service | Front door      | authcache        | Authentication cache                  | [mahi](https://github.com/joyent/mahi) (redis)                                                         |
-| Service | Metadata        | postgres         | Metadata storage and replication      | postgres, [manatee](https://github.com/joyent/manta-manatee)                                           |
-| Service | Metadata        | moray            | Key-value store                       | [moray](https://github.com/joyent/moray)                                                               |
-| Service | Metadata        | electric-moray   | Consistent hashing (sharding)         | [electric-moray](https://github.com/joyent/electric-moray)                                             |
-| Service | Storage         | storage          | Object storage and capacity reporting | [mako](https://github.com/joyent/manta-mako) (nginx), [minnow](https://github.com/joyent/manta-minnow) |
-| Service | Operations      | ops              | GC, audit, and metering cron jobs     | [mola](https://github.com/joyent/manta-mola), [mackerel](https://github.com/joyent/manta-mackerel)     |
-| Service | Operations      | madtom           | Web-based Manta monitoring            | [madtom](https://github.com/joyent/manta-madtom)                                                       |
-| Service | Operations      | marlin-dashboard | Web-based Marlin monitoring           | [marlin-dashboard](https://github.com/joyent/manta-marlin-dashboard)                                   |
+| Service | Consensus       | nameservice      | Service discovery                     | ZooKeeper, [binder](https://github.com/TritonDataCenter/binder) (DNS)                                            |
+| Service | Front door      | loadbalancer     | SSL termination and load balancing    | stud, haproxy/[muppet](https://github.com/TritonDataCenter/muppet)                                               |
+| Service | Front door      | webapi           | Manta HTTP API server                 | [muskie](https://github.com/TritonDataCenter/manta-muskie)                                                       |
+| Service | Front door      | authcache        | Authentication cache                  | [mahi](https://github.com/TritonDataCenter/mahi) (redis)                                                         |
+| Service | Metadata        | postgres         | Metadata storage and replication      | postgres, [manatee](https://github.com/TritonDataCenter/manta-manatee)                                           |
+| Service | Metadata        | moray            | Key-value store                       | [moray](https://github.com/TritonDataCenter/moray)                                                               |
+| Service | Metadata        | electric-moray   | Consistent hashing (sharding)         | [electric-moray](https://github.com/TritonDataCenter/electric-moray)                                             |
+| Service | Storage         | storage          | Object storage and capacity reporting | [mako](https://github.com/TritonDataCenter/manta-mako) (nginx), [minnow](https://github.com/TritonDataCenter/manta-minnow) |
+| Service | Operations      | ops              | GC, audit, and metering cron jobs     | [mola](https://github.com/TritonDataCenter/manta-mola), [mackerel](https://github.com/TritonDataCenter/manta-mackerel)     |
+| Service | Operations      | madtom           | Web-based Manta monitoring            | [madtom](https://github.com/TritonDataCenter/manta-madtom)                                                       |
+| Service | Operations      | marlin-dashboard | Web-based Marlin monitoring           | [marlin-dashboard](https://github.com/TritonDataCenter/manta-marlin-dashboard)                                   |
 | Service | Compute         | jobsupervisor    | Distributed job orchestration         | jobsupervisor                                                                                          |
-| Service | Compute         | jobpuller        | Job archival                          | [wrasse](https://github.com/joyent/manta-wrasse)                                                       |
-| Service | Compute         | marlin           | Compute containers for end users      | [marlin-lackey](https://github.com/joyent/manta-marlin)                                                |
-| Agent   | Compute         | marlin-agent     | Job execution on each storage node    | [marlin-agent](https://github.com/joyent/manta-marlin)                                                 |
-| Agent   | Compute         | medusa           | Interactive Session Engine            | [medusa](https://github.com/joyent/manta-medusa)                                                       |
+| Service | Compute         | jobpuller        | Job archival                          | [wrasse](https://github.com/TritonDataCenter/manta-wrasse)                                                       |
+| Service | Compute         | marlin           | Compute containers for end users      | [marlin-lackey](https://github.com/TritonDataCenter/manta-marlin)                                                |
+| Agent   | Compute         | marlin-agent     | Job execution on each storage node    | [marlin-agent](https://github.com/TritonDataCenter/manta-marlin)                                                 |
+| Agent   | Compute         | medusa           | Interactive Session Engine            | [medusa](https://github.com/TritonDataCenter/manta-medusa)                                                       |
 
 
 ## Consensus and internal service discovery
@@ -344,12 +345,12 @@ In a nutshell, this works like this:
 3. When an instance starts up (e.g., a "moray" zone), an SMF service called the
    *registrar* connects to the ZooKeeper cluster (using the IP addresses
    configured with the zone) and publishes its own IP to ZooKeeper.  A moray
-   zone for shard 1 in region "us-east" publishes its own IP under
-   "1.moray.us-east.joyent.us".
+   zone for shard 1 in region "us-central" publishes its own IP under
+   "1.moray.us-central.mnx.io".
 4. When a client wants to contact the shard 1 moray, it makes a DNS request for
-   1.moray.us-east.joyent.us using the DNS servers in the ZooKeeper cluster.
+   1.moray.us-central.mnx.io using the DNS servers in the ZooKeeper cluster.
    Those DNS servers returns *all* IPs that have been published for
-   1.moray.us-east.joyent.us.
+   1.moray.us-central.mnx.io.
 5. If the registrar in the 1.moray zone dies, the corresponding entry in the
    ZooKeeper data store is automatically removed, causing that zone to fall out
    of DNS.  Due to DNS TTLs of 60s, it may take up to a minute for clients to
@@ -361,7 +362,7 @@ Internally, most services work this way.
 
 Since we don't control Manta clients, the external service discovery system is
 simpler and more static.  We manually configure the public
-`us-east.manta.joyent.com` DNS name to resolve to each of the loadbalancer
+`us-central.manta.mnx.io` DNS name to resolve to each of the loadbalancer
 public IP addresses.  After a request reaches the loadbalancers, everything uses
 the internal service discovery mechanism described above to contact whatever
 other services they need.
@@ -463,7 +464,7 @@ There are actually three kinds of metadata in Manta:
 * Compute job state, which is all stored on a single shard.  This is extremely
   high volume, depending on job load.
 
-In the us-east production deployment, shard 1 stores compute job state and
+In the us-central production deployment, shard 1 stores compute job state and
 storage node capacity.  Shards 2-4 store the object metadata.
 
 Manta supports **resharding** object metadata, which would typically be used to
@@ -807,7 +808,7 @@ Even-numbered configurations are not supported.  See "Other configurations"
 below for details.
 
 A single-datacenter installation can be made to survive server failure, but
-obviously cannot survive datacenter failure.  The us-east deployment uses three
+obviously cannot survive datacenter failure.  The us-central deployment uses three
 datacenters.
 
 ## Choosing the number of metadata shards
@@ -815,7 +816,7 @@ datacenters.
 Recall that each metadata shard has the storage and load capacity of a single
 postgres instance.  If you want more capacity than that, you need more shards.
 Shards can be added later without downtime, but it's a delicate operation.  The
-us-east deployment uses three metadata shards, plus a separate shard for the
+us-central deployment uses three metadata shards, plus a separate shard for the
 compute and storage capacity data.
 
 We recommend at least two shards so that the compute and storage capacity
@@ -833,33 +834,31 @@ and (secondarily) the desired compute capacity.
 The number of non-storage nodes required is a function of the expected load on
 the metadata tier.  Since the point of shards is to distribute load, each
 shard's postgres instance should be on a separate compute node.  So you want at
-least as many compute nodes as you will have shards.  The us-east deployment
+least as many compute nodes as you will have shards.  The us-central deployment
 distributes the other services on those same compute nodes.
 
-For information on the latest recommended production hardware, see [Joyent
-Manufacturing Matrix](http://eng.joyent.com/manufacturing/matrix.html) and
-[Joyent Manufacturing Bill of
-Materials](http://eng.joyent.com/manufacturing/bom.html).
+For information on the latest recommended production hardware, see [Triton
+Manufacturing Matrix](http://eng.tritondatacenter.com/manufacturing/matrix.html) and
+[Triton Manufacturing Bill of
+Materials](http://eng.tritondatacenter.com/manufacturing/bom.html).
 
-The us-east deployment uses older versions of the Tenderloin-A for service
+The us-central deployment uses older versions of the Tenderloin-A for service
 nodes and Mantis Shrimps for storage nodes.
 
 ## Choosing how to lay out zones
 
 Since there are so many different Manta components, and they're all deployed
-redundantly, there are a lot of different pieces to think about.  (The
-production deployment in us-east has 21 zones in *each* of the three
-datacenters, not including the Marlin compute zones.)  So when setting up a
-Manta deployment, it's very important to think ahead of time about which
-components will run where!
+redundantly, there are a lot of different pieces to think about.  So when
+setting up a Manta deployment, it's very important to think ahead of time about
+which components will run where!
 
 **The `manta-adm genconfig` tool (when used with the --from-file option) can be
 very helpful in laying out zones for Manta.  See the `manta-adm` manual page for
 details.**  `manta-adm genconfig --from-file` takes as input a list of physical
 servers and information about each one.  Large deployments that use Device 42 to
 manage hardware inventory may find the
-[manta-genazconfig](https://github.com/joyent/manta-genazconfig) tool useful for
-constructing the input for `manta-adm genconfig`.
+[manta-genazconfig](https://github.com/TritonDataCenter/manta-genazconfig) tool
+useful for constructing the input for `manta-adm genconfig`.
 
 The most important production configurations are described below,
 but for reference, here are the principles to keep in mind:
@@ -1011,8 +1010,8 @@ multi-DC, multi-compute-node deployment.  The general process is:
 
         headnode$ /zones/$(vmadm lookup alias=manta0)/root/opt/smartdc/manta-deployment/networking/gen-coal.sh > /var/tmp/netconfig.json
 
-    b. For those using the internal Joyent Engineering lab, run this from
-       the [lab.git repo](https://mo.joyent.com/docs/lab/master/):
+    b. For those using the internal Engineering lab, run this from
+       the [lab.git repo](https://mo.tritondatacenter.com/docs/lab/master/):
 
         lab.git$ node bin/genmanta.js -r RIG_NAME LAB_NAME
 
@@ -1033,12 +1032,12 @@ multi-DC, multi-compute-node deployment.  The general process is:
    datacenter.
 
 5. For multi-datacenter deployments, you must [link the datacenters within
-   Triton](https://docs.joyent.com/private-cloud/install/headnode-installation/linked-data-centers)
+   Triton](https://docs.tritondatacenter.com/private-cloud/install/headnode-installation/linked-data-centers)
    so that the UFDS database is replicated across all three datacenters.
 
 6. For multi-datacenter deployments, you must [configure SAPI for
    multi-datacenter
-   support](https://github.com/joyent/sdc-sapi/blob/master/docs/index.md#multi-dc-mode).
+   support](https://github.com/TritonDataCenter/sdc-sapi/blob/master/docs/index.md#multi-dc-mode).
 
 7. If you'll be deploying a loadbalancer on any compute nodes *other* than a
    headnode, then you'll need to create the "external" NIC tag on those CNs.
@@ -1046,7 +1045,7 @@ multi-DC, multi-compute-node deployment.  The general process is:
    usually need to do anything for this step.  For multi-CN configurations,
    you probably *will* need to do this.  See the Triton documentation for
    [how to add a NIC tag to a
-   CN](https://docs.joyent.com/sdc7/nic-tags#AssigningaNICTagtoaComputeNode).
+   CN](https://docs.tritondatacenter.com/sdc7/nic-tags#AssigningaNICTagtoaComputeNode).
 
 8. In each datacenter's manta deployment zone, run the following:
 
@@ -1204,7 +1203,7 @@ should consider doing to ensure a working deployment.
 
 ### Prerequisites
 
-If you haven't already done so, you will need to [install the Manta CLI tools](https://github.com/joyent/node-manta#installation).
+If you haven't already done so, you will need to [install the Manta CLI tools](https://github.com/TritonDataCenter/node-manta#installation).
 
 ### Set up a Manta Account
 
@@ -1214,16 +1213,16 @@ accounts or setup your own. The most common method is to test using the
 `poseidon` account which is created by the Manta install.
 
 In either case, you will need access to the Operations Portal. [See the
-instructions here](https://docs.joyent.com/private-cloud/install/headnode-installation#adding-external-access-to-adminui-and-imgapi) on how to find the IP address of the Operations Portal from
+instructions here](https://docs.tritondatacenter.com/private-cloud/install/headnode-installation#adding-external-access-to-adminui-and-imgapi) on how to find the IP address of the Operations Portal from
 your headnode.
 
 Log into the Operations Portal:
 
- * COAL users should use login `admin` and the password [you initially setup](https://github.com/joyent/triton/blob/master/docs/developer-guide/coal-setup.md#configure-the-headnode).
+ * COAL users should use login `admin` and the password [you initially setup](https://github.com/TritonDataCenter/triton/blob/master/docs/developer-guide/coal-setup.md#configure-the-headnode).
  * Lab users will also use `admin`, but need to ask whoever
    provisioned your lab account for the password.
 
-Once in, follow [these instructions](https://docs.joyent.com/private-cloud/users#portalsshkeys) to add ssh keys to the account of your choice.
+Once in, follow [these instructions](https://docs.tritondatacenter.com/private-cloud/users#portalsshkeys) to add ssh keys to the account of your choice.
 
 ### Test Manta from the CLI Tools
 
@@ -1232,7 +1231,7 @@ existing account, you can test your Manta install with the Manta CLI
 tools you installed above in "Prerequisites".
 
 There are complete instructions on how to get started with the CLI
-tools [on the apidocs page](https://apidocs.joyent.com/manta/#getting-started).
+tools [on the apidocs page](https://apidocs.tritondatacenter.com/manta/#getting-started).
 
 Some things in that guide will not be as clear for users of custom deployments.
 
@@ -1343,7 +1342,7 @@ should always eventually be cleared**.
 
 For more sophisticated progress monitoring, see the node-artedi probes described
 in the garbage-collector
-[readme](https://github.com/joyent/manta-garbage-collector/blob/master/README.md).
+[readme](https://github.com/TritonDataCenter/manta-garbage-collector/blob/master/README.md).
 
 #### Deploy garbage-collector zones
 
@@ -1555,7 +1554,7 @@ force distribution of these global zone services.
 
 Note: For global zone network changes handled by boot-time networking to
 take effect, a reboot of the node must be performed. See
-[Triton's virtual networking documentation](https://docs.joyent.com/private-cloud/networks/sdn/architecture#bootstrapping-networking-state-in-the-global-zone)
+[Triton's virtual networking documentation](https://docs.tritondatacenter.com/private-cloud/networks/sdn/architecture#bootstrapping-networking-state-in-the-global-zone)
 for more information on boot-time networking.
 
 For reference, here's an example multi-datacenter configuration with one service
@@ -1678,33 +1677,33 @@ A common failure mode with `manta-init ...` for those without a fast internet
 link is a failure to import the large "manta-marlin" image. This is a multi-GB
 image used for the zones in which Manta compute jobs run. The problem is that
 the large image can make it easy to hit the one hour timeout for the
-[IMGAPI AdminImportRemoteImage](https://github.com/joyent/sdc-imgapi/blob/master/docs/index.md#adminimportremoteimage-post-imagesuuidactionimport-remote)
+[IMGAPI AdminImportRemoteImage](https://github.com/TritonDataCenter/sdc-imgapi/blob/master/docs/index.md#adminimportremoteimage-post-imagesuuidactionimport-remote)
 endpoint used to import Manta images. Neither this endpoint nor the
-<https://updates.joyent.com> server hosting the images supports resumable
+<https://updates.tritondatacenter.com> server hosting the images supports resumable
 downloads.
 
 Here is a manual workaround (run the following from the headnode global zone):
 
     cd /var/tmp
 
-    # Determine the UUID of the latest "manta-marlin" image on updates.joyent.com.
+    # Determine the UUID of the latest "manta-marlin" image on updates.tritondatacenter.com.
     muuid=$(updates-imgadm list name=manta-marlin --latest -H -o uuid)
 
     # Download directly from a separate manual download area in Manta.
-    curl -kO https://us-east.manta.joyent.com/Joyent_Dev/public/Manta/manta-marlin-image/$muuid.imgmanifest
+    curl -kO https://us-central.manta.mnx.io/Joyent_Dev/public/Manta/manta-marlin-image/$muuid.imgmanifest
 
     # First ensure that the origin (i.e. parent) image is installed
     origin=$(json -f $muuid.imgmanifest origin)
     [[ -z "$origin" ]] \
         || sdc-imgadm get $origin >/dev/null \
-        || sdc-imgadm import $origin -S https://updates.joyent.com
+        || sdc-imgadm import $origin -S https://updates.tritondatacenter.com
 
     # If that failed, then the separate download area doesn't have a recent
     # image. Please log an issue.
-    [[ $? -ne 0 ]] && echo log an issue at https://github.com/joyent/manta/issues/
+    [[ $? -ne 0 ]] && echo log an issue at https://github.com/TritonDataCenter/manta/issues/
 
     # If the following is interrupted, then re-run the same command to resume:
-    curl -kO -C - https://us-east.manta.joyent.com/Joyent_Dev/public/Manta/manta-marlin-image/$muuid.file.gz
+    curl -kO -C - https://us-central.manta.mnx.io/Joyent_Dev/public/Manta/manta-marlin-image/$muuid.file.gz
 
     # Verify the download checksum
     [[ $(json -f $muuid.imgmanifest | json files.0.sha1) \
@@ -1860,9 +1859,9 @@ Run this in each datacenter:
 
 1. Download updated images.  The supported approach is to re-run the
    `manta-init` command that you used when initially deploying Manta inside the
-   manta-deployment zone.  For us-east, use:
+   manta-deployment zone.  For us-central, use:
 
-        $ manta-init -e manta+us-east@joyent.com -s production -c 10
+        $ manta-init -e manta+us-central@tritondatacenter.com -s production -c 10
 
    **Do not run `manta-init` concurrently in multiple datacenters.**
 
@@ -1947,7 +1946,7 @@ available to end users simultaneously.  One image is configured as the default.
 End users can request other available images on a per-job-phase basis.  While
 [user documentation recommends that users always specify which image they want
 to
-use](https://apidocs.joyent.com/manta/jobs-reference.html#compute-instance-images-image-property),
+use](https://apidocs.tritondatacenter.com/manta/jobs-reference.html#compute-instance-images-image-property),
 most users do not use this option, so most jobs end up using the default image.
 
 Because the software in compute zones is directly exposed to end users,
@@ -2011,7 +2010,7 @@ zone image `1757ab74-b3ed-11e2-b40f-c7adac046f18` to compute zone image
    current image used for new Manta deployments, "manta-init" can be used to
    download and import the new image.  Otherwise, import it explicitly with
    "sdc-imgadm import", as in `sdc-imgadm import
-   bb9264e2-f134-11e3-9ec7-478da02d1a13 -S https://updates.joyent.com`.
+   bb9264e2-f134-11e3-9ec7-478da02d1a13 -S https://updates.tritondatacenter.com`.
 2. Use `manta-adm show -s -j > config.json` to generate a configuration file
    describing the zones currently deployed in the datacenter.  This file should
    have a number of "marlin" blocks that look like this:
@@ -2244,7 +2243,7 @@ See "Amon Alarm Updates".
 Manta integrates with **Amon**, the Triton alarming and monitoring system, to
 notify operators when something is wrong with a Manta deployment.  It's
 recommended to review Amon basics in the [Amon
-documentation](https://github.com/joyent/sdc-amon/blob/master/docs/index.md).
+documentation](https://github.com/TritonDataCenter/sdc-amon/blob/master/docs/index.md).
 
 The `manta-adm` tool ships with configuration files that specify Amon probes and
 probe groups, referred to elsewhere as the "Amon configuration" for Manta.  This
@@ -2350,7 +2349,7 @@ are three common patterns:
 Most custom services use the bunyan format.  The "bunyan" tool is installed in
 /usr/bin to view these logs.  You can also [snoop logs of running services in
 more detail using bunyan's built-in DTrace
-probes](http://www.joyent.com/blog/node-js-in-production-runtime-log-snooping).
+probes](http://www.tritondatacenter.com/blog/node-js-in-production-runtime-log-snooping).
 If you find yourself needing to look at the *current* log file for a component
 (i.e., can't wait for the next hourly upload into Manta), here's a reference for
 the service's that *don't* use the SMF log file:
@@ -2664,7 +2663,7 @@ interface that each garbage-collector runs on startup:
 
 The admin interface exposes a number of other endpoints. For an exhaustive list,
 see the garbage-collector
-[README](https://github.com/joyent/manta-garbage-collector/blob/master/README.md).
+[README](https://github.com/TritonDataCenter/manta-garbage-collector/blob/master/README.md).
 
 The mapping between garbage-collector instances and shards can also be read via
 manta-adm:
@@ -2772,10 +2771,10 @@ the current datacenter:
 
     # manta-adm cn -o host,compute_id,storage_ids storage
     HOST     COMPUTE ID               STORAGE IDS
-    RM08213  12.cn.us-east.joyent.us  2.stor.us-east.joyent.us
-    RM08211  20.cn.us-east.joyent.us  1.stor.us-east.joyent.us
-    RM08216  19.cn.us-east.joyent.us  3.stor.us-east.joyent.us
-    RM08219  11.cn.us-east.joyent.us  4.stor.us-east.joyent.us
+    RM08213  12.cn.us-central.mnx.io  2.stor.us-central.mnx.io
+    RM08211  20.cn.us-central.mnx.io  1.stor.us-central.mnx.io
+    RM08216  19.cn.us-central.mnx.io  3.stor.us-central.mnx.io
+    RM08219  11.cn.us-central.mnx.io  4.stor.us-central.mnx.io
 
 Note that the column name is "storage\_ids" (with a trailing "s") since there
 may be more than one.
@@ -2837,16 +2836,16 @@ You run this inside any "muskie" (webapi) zone:
       "sharks": [
         {
           "datacenter": "staging-2",
-          "manta_storage_id": "2.stor.staging.joyent.us"
+          "manta_storage_id": "2.stor.staging.mnx.io"
         },
         {
           "datacenter": "staging-1",
-          "manta_storage_id": "1.stor.staging.joyent.us"
+          "manta_storage_id": "1.stor.staging.mnx.io"
         }
       ],
-      "_moray": "tcp://electric-moray.staging.joyent.us:2020",
+      "_moray": "tcp://electric-moray.staging.mnx.io:2020",
       "_node": {
-        "pnode": "tcp://3.moray.staging.joyent.us:2020",
+        "pnode": "tcp://3.moray.staging.mnx.io:2020",
         "vnode": 7336153,
         "data": 1
       }
@@ -2890,9 +2889,9 @@ this to print out the full mapping:
 
     # manta-adm show -a -o storage_id,datacenter,zonename storage
     STORAGE ID                 DATACENTER ZONENAME
-    1.stor.staging.joyent.us   staging-1  f7954cad-7e23-434f-be98-f077ca7bc4c0
-    2.stor.staging.joyent.us   staging-2  12fa9eea-ba7a-4d55-abd9-d32c64ae1965
-    3.stor.staging.joyent.us   staging-3  6dbfb615-b1ac-4f9a-8006-2cb45b87e4cb
+    1.stor.staging.mnx.io      staging-1  f7954cad-7e23-434f-be98-f077ca7bc4c0
+    2.stor.staging.mnx.io      staging-2  12fa9eea-ba7a-4d55-abd9-d32c64ae1965
+    3.stor.staging.mnx.io      staging-3  6dbfb615-b1ac-4f9a-8006-2cb45b87e4cb
 
 Then use "manta-login" to log into the corresponding storage zone:
 
@@ -2949,7 +2948,7 @@ look something like this:
       267786 204
       ...
 
-(You can also use [Dragnet](https://github.com/joyent/dragnet) to scan logs more
+(You can also use [Dragnet](https://github.com/TritonDataCenter/dragnet) to scan logs more
 quickly.)
 
 That output indicates 294,000 requests with code 200, 268,000 requests with code
@@ -3016,9 +3015,9 @@ servers to debug that.
 Manta performs a number of housekeeping operations that are based on the
 contents of the metadata tier, including garbage collection, auditing, metering,
 and object rebalancing.  These are documented with the
-[Mola](https://github.com/joyent/manta-mola) project, particularly under
+[Mola](https://github.com/TritonDataCenter/manta-mola) project, particularly under
 ["system
-crons"](https://github.com/joyent/manta-mola/blob/master/docs/system-crons.md).
+crons"](https://github.com/TritonDataCenter/manta-mola/blob/master/docs/system-crons.md).
 In summary: a pipeline gets kicked off daily that saves database dumps of the
 metadata tier into Manta itself and then uses normal Manta jobs to first unpack
 these dumps and then process them for these various purposes.  If any of these
@@ -3026,9 +3025,9 @@ steps fails, manual intervention may be required to complete these operations.
 
 If the pipeline has failed, it's important to figure out why.  In practice, the
 most common reason is that the database dumps were not uploaded on time.  The
-[manta-hk](https://github.com/joyent/manta-hk) tool is provided to help figure
+[manta-hk](https://github.com/TritonDataCenter/manta-hk) tool is provided to help figure
 this out.  Its [manual
-page](https://github.com/joyent/manta-hk/blob/master/docs/man/manta-hk.md)
+page](https://github.com/TritonDataCenter/manta-hk/blob/master/docs/man/manta-hk.md)
 describes its usage.
 
 **When this pipeline has failed, use the manta-hk tool to determine whether
@@ -3041,7 +3040,7 @@ checks for the objects that normally get unpacked into the same directory, which
 may look like this (though the set of objects differs based on what the shard is
 being used for):
 
-    # mls /poseidon/stor/manatee_backups/2.moray.us-east.joyent.us/2015/06/02/00
+    # mls /poseidon/stor/manatee_backups/2.moray.us-central.mnx.io/2015/06/02/00
     buckets_config-2015-06-02-00-00-33.gz
     manta-2015-06-02-00-00-33.gz
     manta_delete_log-2015-06-02-00-00-33.gz
@@ -3091,7 +3090,7 @@ If the database dump is present, but none of the other objects are present, then
 the dump was not successfully unpacked.  You can kick off a job to do this by
 running a command like this one from the "ops" zone:
 
-    # /opt/smartdc/mola/bin/kick_off_pg_transform.js -b /poseidon/stor/manatee_backups/2.moray.us-east.joyent.us/2015/06/02/00/moray-2015-06-02-00-00-37.gz 2>&1 | bunyan
+    # /opt/smartdc/mola/bin/kick_off_pg_transform.js -b /poseidon/stor/manatee_backups/2.moray.us-central.mnx.io/2015/06/02/00/moray-2015-06-02-00-00-37.gz 2>&1 | bunyan
 
 The argument for the "-b" option is the name of the database dump object in
 Manta.  You'll need to run this command for each dump that you want to unpack
@@ -3223,7 +3222,7 @@ Use `mrjob where` to list uncompleted tasks and see where they're running:
 
     ops$ mrjob where e493ab87-fcf0-e991-8b82-8f649696d197
     TASKID                               PH       NIN SERVER
-    6ce64b78-691b-4703-970a-de2fb84b69f1  0         - 1.cn.us-east.joyent.us
+    6ce64b78-691b-4703-970a-de2fb84b69f1  0         - 1.cn.us-central.mnx.io
          map: /dap/stor/mdb.log
 
 Note that physical storage nodes in Manta are identified by mantaComputeId
@@ -3283,14 +3282,14 @@ Here's a normal history for one of the first phase tasks:
         /dap/stor/datasets/cmd/cmd/acct/acctcms.c
 
     2014-01-17T19:22:03.746Z  map task   33b7f617-141e-4673-8056-a27a6f511b60
-                                         (attempt 1, host 11.cn.us-east.joyent.us)
+                                         (attempt 1, host 11.cn.us-central.mnx.io)
         /dap/stor/datasets/cmd/cmd/acct/acctcms.c
 
     2014-01-17T19:22:04.142Z  taskoutput b9bb82de-416d-4ac3-a962-09f75a140932
         /dap/jobs/ea784e03-a735-cd29-d913-b1b9cb5f0503/stor/dap/stor/datasets/cmd/cmd/acct/acctcms.c.0.33b7f617-141e-4673-8056-a27a6f511b60
 
     2014-01-17T19:22:08.663Z  map task   1b370599-90b3-4c03-a388-c8967798d396
-                                         (attempt 1, host 25.cn.us-east.joyent.us)
+                                         (attempt 1, host 25.cn.us-central.mnx.io)
 
     2014-01-17T19:22:09.078Z  taskoutput c98b68d1-1b76-4adf-845c-f7392d860694
         /dap/jobs/ea784e03-a735-cd29-d913-b1b9cb5f0503/stor/dap/stor/datasets/cmd/cmd/acct/acctcms.c.1.1b370599-90b3-4c03-a388-c8967798d396
@@ -3299,7 +3298,7 @@ Here's a normal history for one of the first phase tasks:
         /dap/jobs/ea784e03-a735-cd29-d913-b1b9cb5f0503/stor/dap/stor/datasets/cmd/cmd/acct/acctcms.c.1.1b370599-90b3-4c03-a388-c8967798d396
 
     2014-01-17T19:22:02.447Z  reducer    015f6dbb-8bb3-4b07-b806-12bdf46fd8a8
-                                         (attempt 1, host 11.cn.us-east.joyent.us)
+                                         (attempt 1, host 11.cn.us-central.mnx.io)
                                          4 inputs
 
 This shows the jobinput that created the task, the output from the task that
@@ -3317,7 +3316,7 @@ retried:
         /dap/stor/datasets/cmd/cmd/addbadsec/addbadsec.c
 
     2014-01-17T19:22:03.660Z  map task   a322ebe6-3279-40ee-8c7e-88130def17b4
-                                         (attempt 1, host 9.cn.us-east.joyent.us)
+                                         (attempt 1, host 9.cn.us-central.mnx.io)
         /dap/stor/datasets/cmd/cmd/addbadsec/addbadsec.c
 
     2014-01-17T19:22:06.411Z  error      bb08a232-75d6-4b59-a80c-3f369f84d64a
@@ -3325,14 +3324,14 @@ retried:
                                          internal error: agent timed out
 
     2014-01-17T19:22:07.551Z  map task   e4c80edb-5302-4f6f-af19-336be9834e92
-                                         (attempt 2, host 26.cn.us-east.joyent.us)
+                                         (attempt 2, host 26.cn.us-central.mnx.io)
         /dap/stor/datasets/cmd/cmd/addbadsec/addbadsec.c
 
     2014-01-17T19:22:07.679Z  taskoutput c79dc94d-5800-4e59-b808-998c94024c2f
         /dap/jobs/ea784e03-a735-cd29-d913-b1b9cb5f0503/stor/dap/stor/datasets/cmd/cmd/addbadsec/addbadsec.c.0.e4c80edb-5302-4f6f-af19-336be9834e92
 
     2014-01-17T19:22:12.279Z  map task   c6cbe67f-2c9d-4c50-ae0c-53590303f544
-                                         (attempt 1, host 19.cn.us-east.joyent.us)
+                                         (attempt 1, host 19.cn.us-central.mnx.io)
 
     2014-01-17T19:22:12.529Z  taskoutput 70275969-c92f-4700-96c2-9564158be0b2
         /dap/jobs/ea784e03-a735-cd29-d913-b1b9cb5f0503/stor/dap/stor/datasets/cmd/cmd/addbadsec/addbadsec.c.1.c6cbe67f-2c9d-4c50-ae0c-53590303f544
@@ -3341,7 +3340,7 @@ retried:
         /dap/jobs/ea784e03-a735-cd29-d913-b1b9cb5f0503/stor/dap/stor/datasets/cmd/cmd/addbadsec/addbadsec.c.1.c6cbe67f-2c9d-4c50-ae0c-53590303f544
 
     2014-01-17T19:22:02.447Z  reducer    6e009faa-a0d8-478a-9b66-ae82852fbf45
-                                         (attempt 1, host 25.cn.us-east.joyent.us)
+                                         (attempt 1, host 25.cn.us-central.mnx.io)
                                          7 inputs
 
 In this case, we see the map task we asked about, the error it produced, and the map retry task below it on a different host.
@@ -3350,7 +3349,7 @@ Here's what happens when we select a reducer that failed:
 
     ops$ mrjob taskhistory 3ac67932-75ba-4ce0-891e-1b295949a3be
     2014-01-17T19:22:02.447Z  reducer    3ac67932-75ba-4ce0-891e-1b295949a3be
-                                         (attempt 1, host 9.cn.us-east.joyent.us)
+                                         (attempt 1, host 9.cn.us-central.mnx.io)
                                          input stream open
 
     2014-01-17T19:22:06.424Z  error      c3923a5f-93ea-425e-92c3-694b6bf08b3d
@@ -3358,7 +3357,7 @@ Here's what happens when we select a reducer that failed:
                                          internal error: agent timed out
 
     2014-01-17T19:22:07.542Z  reducer    c98bd373-6c08-4032-b405-bf0a0e18f820
-                                         (attempt 2, host 12.cn.us-east.joyent.us)
+                                         (attempt 2, host 12.cn.us-central.mnx.io)
                                          9 inputs
 
 We don't see any of the previous or subsequent phase tasks because
@@ -3377,20 +3376,20 @@ attempt:
         /dap/stor/datasets/cmd/cmd/acct/acctwtmp.c
 
     2014-01-17T19:22:03.633Z  map task   4906e7b9-c65e-4655-95d0-5bdcbda62b39
-                                         (attempt 1, host 26.cn.us-east.joyent.us)
+                                         (attempt 1, host 26.cn.us-central.mnx.io)
         /dap/stor/datasets/cmd/cmd/acct/acctwtmp.c
 
     2014-01-17T19:22:04.164Z  taskoutput 41dd8fac-2923-42ec-a893-43318596472b
         /dap/jobs/ea784e03-a735-cd29-d913-b1b9cb5f0503/stor/dap/stor/datasets/cmd/cmd/acct/acctwtmp.c.0.4906e7b9-c65e-4655-95d0-5bdcbda62b39
 
     2014-01-17T19:22:07.380Z  map task   94851372-49b9-48fd-b5ca-b51b330561ab
-                                         (attempt 1, host 293.cn.us-east.joyent.us)
+                                         (attempt 1, host 293.cn.us-central.mnx.io)
 
     2014-01-17T19:22:07.604Z  taskoutput 5cbb34ab-a0f4-4144-9629-629d323cc1f0
         /dap/jobs/ea784e03-a735-cd29-d913-b1b9cb5f0503/stor/dap/stor/datasets/cmd/cmd/acct/acctwtmp.c.1.94851372-49b9-48fd-b5ca-b51b330561ab
 
     2014-01-17T19:22:02.447Z  reducer    660f7838-4055-49b3-8376-dec9648ec2a5
-                                         (attempt 1, host 9.cn.us-east.joyent.us)
+                                         (attempt 1, host 9.cn.us-central.mnx.io)
                                          input stream open
 
     2014-01-17T19:22:06.397Z  error      4263bcc0-3a5e-433b-9460-b5970044cb51
@@ -3401,7 +3400,7 @@ attempt:
         /dap/jobs/ea784e03-a735-cd29-d913-b1b9cb5f0503/stor/dap/stor/datasets/cmd/cmd/acct/acctwtmp.c.1.94851372-49b9-48fd-b5ca-b51b330561ab
 
     2014-01-17T19:22:07.539Z  reducer    318b47e5-a234-4fa0-b11e-e80701cfc90d
-                                         (attempt 2, host 9.cn.us-east.joyent.us)
+                                         (attempt 2, host 9.cn.us-central.mnx.io)
                                          input stream open
 
     2014-01-17T19:22:11.437Z  error      681faf97-2ae5-4938-89a8-d422e7156d11
@@ -3409,7 +3408,7 @@ attempt:
                                          internal error: agent timed out
 
     2014-01-17T19:22:12.689Z  reducer    721187a7-5df1-4ce1-9c3b-9e54ffd71cce
-                                         (attempt 3, host 20.cn.us-east.joyent.us)
+                                         (attempt 3, host 20.cn.us-central.mnx.io)
                                          6 inputs
 
 ## Using the Moray tools to fetch detailed state
@@ -3574,7 +3573,7 @@ Each instruction contains a variable number of lines referring to object
 backing-files on a storage server. These are formatted to match the expectations
 of the existing storage server cron job. For more about this format and running
 Mako cleaning steps manually, see
-[documentation](https://github.com/joyent/manta-mola/blob/master/docs/gc-manual-coal.md#cleaning-makos)
+[documentation](https://github.com/TritonDataCenter/manta-mola/blob/master/docs/gc-manual-coal.md#cleaning-makos)
 in the Mola consolidation.
 
 To check the number of instruction objects for a particular shark:
@@ -3781,10 +3780,10 @@ mrjob only shows overall system state.  Once a task is issued to a server, you
 have to contact the agent running on that server to figure out the status.  The
 dashboard shows running groups and streams, but you can get more information by
 logging into the box and running the "mrgroups" and "mrzones" tools.
-Continuing the above example, 25.cn.us-east.joyent.us corresponds to MS08214 in
-us-east-1, so we can log into that box and run `mrgroups`:
+Continuing the above example, 25.cn.us-central.mnx.io corresponds to MS08214 in
+us-central-1, so we can log into that box and run `mrgroups`:
 
-    [root@MS08214 (us-east-1) ~]# mrgroups
+    [root@MS08214 (us-central-1) ~]# mrgroups
     JOBID                                PH NTASKS RUN SHARE  LOGIN
     4ff04c4d-4540-483d-94ca-d515320d2b9d  0      0   1      1 dap
     946587d1-3ef6-46d5-b139-186d59813f9d  3      1   0      1 poseidon
@@ -3794,7 +3793,7 @@ job will have two groups on each physical server where it's running.  Each
 group may have multiple "streams" associated with it, each corresponding to a
 compute zone where tasks are running.  We can see these with:
 
-    [root@MS08214 (us-east-1) ~]# mrgroups -s
+    [root@MS08214 (us-central-1) ~]# mrgroups -s
     JOBID       PH ZONE                                 LAST START
     4ff04c4d...  0 1118c00b-4729-4c18-a289-f54afe2d9e9d 2013-07-02T22:16:17.746Z
     946587d1...  3 4836fd7b-d80d-4b2d-8519-8955ca5621ff 2013-07-02T22:20:30.068Z
@@ -3808,7 +3807,7 @@ and each group has one zone.  But in general:
 
 You can even see exactly what processes the user's job is running:
 
-    [root@MS08214 (us-east-1) ~]# mrgroups -sv
+    [root@MS08214 (us-central-1) ~]# mrgroups -sv
     JOBID       PH ZONE                                 LAST START
     4ff04c4d...  0 1118c00b-4729-4c18-a289-f54afe2d9e9d 2013-07-02T22:16:17.746Z
       90397 ./node lib/agent.js
@@ -4058,7 +4057,7 @@ indicates when they started.  If you see a number of other processes that have
 been running for several minutes, that's generally a sign that things are in
 bad shape.  Here's an example:
 
-    [root@RM08211 (us-east-2) ~]# svcs -p marlin-agent
+    [root@RM08211 (us-central-2) ~]# svcs -p marlin-agent
     STATE          STIME    FMRI
     online         Dec_20   svc:/smartdc/agent/marlin-agent:default
                    16:54:16    15450 vmadm
@@ -4127,7 +4126,7 @@ into.
 On occasion, a compute zone may transition to the "disabled" state.  These zones
 appear red on the Marlin dashboard and mrzones will report the same:
 
-    [root@RM08211 (us-east-2) ~]# mrzones
+    [root@RM08211 (us-central-2) ~]# mrzones
        5 busy
        1 disabled
      122 ready
@@ -4135,7 +4134,7 @@ appear red on the Marlin dashboard and mrzones will report the same:
 
 Use `mrzones -x` to determine the reason for the zone being disabled:
 
-    [root@RM08211 (us-east-2) ~]# mrzones -x
+    [root@RM08211 (us-central-2) ~]# mrzones -x
     3cf7ccc4-4da2-4a0a-b111-ef4e0c2e04cc (since 2014-07-25T03:00:28.001Z)
         zone not ready: command "zfs rollback zones/3cf7ccc4-4da2-4a0a-b111-ef4e0c2e04cc@marlin_init" failed with stderr: cannot open 'zones/3cf7ccc4-4da2-4a0a-b111-ef4e0c2e04cc@marlin_init': dataset does not exist : child exited with status 1
 
@@ -4294,10 +4293,10 @@ there's the tools/install_marlin_image.sh script.  This script:
 
     manta$ ./tools/install_marlin_image.sh <machine>
 
-will download the latest marlin image from updates.joyent.com, save it on that
+will download the latest marlin image from updates.tritondatacenter.com, save it on that
 machine on which the script is run, and copy it to the machine's IMGAPI.  On
 subsequent runs, this script will copy the image from the local machine and
-avoid downloading it again from updates.joyent.com.  Because the manta-compute
+avoid downloading it again from updates.tritondatacenter.com.  Because the manta-compute
 image is larger than all other images combined, using install_marlin_image.sh
 will shorten the development cycle.
 
@@ -4445,7 +4444,7 @@ external addresses:
     	ether 90:b8:d0:3f:37:e0
     lo0: flags=2002000849<UP,LOOPBACK,RUNNING,MULTICAST,IPv6,VIRTUAL> mtu 8252 index 1
     	inet6 ::1/128
-    [root@0be5c6c1-8ae2-4249-ab64-8c6f1c54363e ~]# nslookup www.joyent.com
+    [root@0be5c6c1-8ae2-4249-ab64-8c6f1c54363e ~]# nslookup www.tritondatacenter.com
     Server:         8.8.8.8
     Address:        8.8.8.8#53
 
@@ -4535,7 +4534,7 @@ Take note of the service uuid and make sure you can fetch it with:
     headnode$ sapiadm update [service uuid] json.path=value
     #Examples:
     headnode$ sapiadm update 8386d8f5-d4ff-4b51-985a-061832b41179 \
-      params.tags.manta_storage_id=2.stor.us-east.joyent.us
+      params.tags.manta_storage_id=2.stor.us-central.mnx.io
     headnode$ sapiadm update update 0b48c067-01bd-41ca-9f70-91bda65351b2 \
       metadata.PG_DIR=/manatee/pg/data
 
@@ -4639,7 +4638,7 @@ Then reboot the zone.
 The information in this section may be useful once you're familiar with Marlin
 internals.  These are internal implementation details intended to help
 *understand* the system.  It is completely unsupported to make any changes to
-the system outside of using a documented tool or following a Joyent support
+the system outside of using a documented tool or following a supported
 procedure.  **Everything in this section is subject to change without
 notice!**
 
@@ -4676,7 +4675,7 @@ through the system.
 
 The schema for these buckets is not documented or stable, but you can find the
 latest version (with comments) on
-[github](https://github.com/joyent/manta-marlin/blob/master/common/lib/schema.js).
+[github](https://github.com/TritonDataCenter/manta-marlin/blob/master/common/lib/schema.js).
 
 
 ## Heartbeats, failures, and health checking
@@ -4731,7 +4730,7 @@ json representation and the full lists of inputs, outputs, and errors into the
 job's directory (`/$MANTA_USER/jobs/$JOBID`).  The job's json representation is
 also saved into `/poseidon/stor/job_archives/YYYY/MM/DD/HH`.  For more on the
 user-facing implications of archiving, see the [public
-docs](http://apidocs.joyent.com/manta/jobs-reference.html#job-completion-and-archival).
+docs](http://apidocs.tritondatacenter.com/manta/jobs-reference.html#job-completion-and-archival).
 
 About 24 hours after a job is archived, all of its records are removed from the
 database.  This is necessary to keep the jobs database from growing without
@@ -4778,17 +4777,17 @@ database:
    example, if the job completed at 2014-05-05T11:07:05.519Z, you'll look at the
    dump for 2014/05/06/00 (the first dump after the completion time).  All of
    the dumps are stored in `/poseidon/stor/manatee_backups`, under the shard
-   designated as the jobs shard.  For the us-east Manta deployment, the jobs
-   shard is 1.moray.us-east.joyent.us.  Putting all this together, the database
+   designated as the jobs shard.  For the us-central Manta deployment, the jobs
+   shard is 1.moray.us-central.mnx.io.  Putting all this together, the database
    dumps we care about would be in:
 
-        /poseidon/stor/manatee_backups/1.moray.us-east.joyent.us/2014/05/06/00
+        /poseidon/stor/manatee_backups/1.moray.us-central.mnx.io/2014/05/06/00
 
    Next, you'll run `mrextractjob` (from the `ops` zone).  You can run it with
    no arguments for details, but basically you'll run something like this:
 
         $ mrextractjob \
-            /poseidon/stor/manatee_backups/1.moray.us-east.joyent.us/2014/05/06/00 \
+            /poseidon/stor/manatee_backups/1.moray.us-central.mnx.io/2014/05/06/00 \
             /poseidon/stor/debug-fe4c6e2a \
             fe4c6e2a-bc78-4c94-d4cd-c9f6a8931855
 

--- a/docs/sample-training.md
+++ b/docs/sample-training.md
@@ -2,11 +2,11 @@
 
 This document outlines sample topics for a training course on operating Manta.
 
-* Docs: 
-    * Manta Overview: https://github.com/joyent/manta
-    * Manta Ops Guide: https://github.com/joyent/manta/blob/master/docs/manta-ops.md
-    * Manatee Users Guide: https://github.com/joyent/manatee/blob/master/docs/user-guide.md
-    * Manatee Troubleshooting Guide: https://github.com/joyent/manatee/blob/master/docs/trouble-shooting.md
+* Docs:
+    * Manta Overview: https://github.com/TritonDataCenter/manta
+    * Manta Ops Guide: https://github.com/TritonDataCenter/manta/blob/master/docs/manta-ops.md
+    * Manatee Users Guide: https://github.com/TritonDataCenter/manatee/blob/master/docs/user-guide.md
+    * Manatee Troubleshooting Guide: https://github.com/TritonDataCenter/manatee/blob/master/docs/trouble-shooting.md
 * Architecture Review
 * Using Manta
     * Get new users set up for Manta

--- a/docs/user-guide/commands-reference.md
+++ b/docs/user-guide/commands-reference.md
@@ -6,12 +6,12 @@ markdown2extras: wiki-tables, code-friendly
 # CLI Utilities Reference
 
 This document lists the command line interface (CLI) tools available from the
-Joyent Manta [Node.js SDK](sdks.html#nodejs-sdk-and-cli) as well as the CLI tools available to you in the
+Manta [Node.js SDK](sdks.html#nodejs-sdk-and-cli) as well as the CLI tools available to you in the
 compute environment.
 
 # Client-Side Utilities
 
-These commands are installed locally on your machine as part of the Joyent Manta Node.js SDK.
+These commands are installed locally on your machine as part of the Manta Node.js SDK.
 They are also available to your jobs in the compute environment.
 
 * [mls](mls.html) - Lists directory contents

--- a/docs/user-guide/compute-instance-software.md
+++ b/docs/user-guide/compute-instance-software.md
@@ -2,12 +2,12 @@
 title: Compute Environment Software
 markdown2extras: wiki-tables, code-friendly
 ---
-    
+
 # Compute Environment Software
-    
-The Joyent Manta Storage Service compute environment is a SmartOS instance with
-most major languages and packages installed including: 
-    
+
+The Manta Storage Service compute environment is a SmartOS instance with
+most major languages and packages installed including:
+
 * Node.js
 * Python
 * Ruby
@@ -17,13 +17,13 @@ most major languages and packages installed including:
 * MySQL client
 * Postgres client
 
-All of the Joyent Manta  command line utilities listed in [CLI Utilities Reference](commands-reference.html)
+All of the Manta  command line utilities listed in [CLI Utilities Reference](commands-reference.html)
 are also available to you in the compute environment.
 
 You can use your own software as [assets](index.html#running-jobs-using-assets) to your job.
 
 This list shows every package installed in the compute environment:
-    
+
     GConf-2.32.4nb6      Configuration database system used by GNOME
     GeoIP-1.4.8          Find the country from any IP address
     GeoLiteCity-201305   Free alternative for the GeoIP City database
@@ -2243,5 +2243,5 @@ This list shows every package installed in the compute environment:
     zookeeper-server-3.4.4 Highly reliable distributed coordination server
     zsh-5.0.2            The Z shell
     zziplib-0.13.59      Library for ZIP archive handling
-    
-    
+
+

--- a/docs/user-guide/compute-instance-utilities.md
+++ b/docs/user-guide/compute-instance-utilities.md
@@ -1,5 +1,5 @@
 ---
-title: Joyent Manta Storage Service
+title: Triton Manta Storage Service
 markdown2extras: wiki-tables, code-friendly
 logo-color: green
 logo-font-family: google:Aldrich, Verdana, sans-serif
@@ -8,7 +8,7 @@ header-font-family: google:Aldrich, Verdana, sans-serif
 
 # manta-compute-bin
 
-[manta-compute-bin](http://joyent.github.com/manta-compute-bin) is a collection
+[manta-compute-bin](http://github.com/TritonDataCenter/manta-compute-bin) is a collection
 of utilities that are on the `$PATH` in a compute job.
 
 # Introduction
@@ -56,8 +56,8 @@ your changes in Compute with something like:
 
 # More documentation
 
-Docs can be found here [http://apidocs.joyent.com/manta/](http://apidocs.joyent.com/manta/)
+Docs can be found here [http://apidocs.tritondatacenter.com/manta/](http://apidocs.tritondatacenter.com/manta/)
 
 # Bugs
 
-See <https://github.com/joyent/manta-compute-bin/issues>.
+See <https://github.com/TritonDataCenter.com/manta-compute-bin/issues>.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -11,7 +11,7 @@ This page is to only use the node.js CLI examples. The curl one is for the web a
 Standard Opening Paragraph
 -->
 
-# Manta: Triton's object storage and converged analytics solution
+# Manta: Triton's object storage solution
 
 Manta, Triton's object storage and converged analytics solution, is a highly scalable, distributed object storage service with integrated compute that enables the creation of analytics jobs (more generally, compute jobs) which process and transform data at rest. Developers can store and process any amount of data at any time where a simple web API call replaces the need for spinning up instances. Manta compute is a complete and high performance compute environment including R, Python, node.js, Perl, Ruby, Java, C/C++, ffmpeg, grep, awk and others. Metering is by the second with zero provisioning, data movement or scheduling latency costs.
 
@@ -49,19 +49,19 @@ Patterns](job-patterns.html) page.
 
 # Real-world systems
 
-These are systems that customers and Joyent engineers have built on top of
+These are systems that customers and tritondatacenter engineers have built on top of
 Manta.
 
 * [Scaling Event-based Data Collection and
   Analysis](http://building.wanelo.com/2013/06/28/a-cost-effective-approach-to-scaling-event-based-data-collection-and-analysis.html):
   Wanelo stores user analytics and analyzes behavior with Manta
 * [500 regression tests in 4
-  minutes](https://www.joyent.com/blog/550-regression-tests-in-4-minutes-with-joyent-manta): The Node team uses Manta to run a test case against all commits in a repository to find which one introduced a regression
+  minutes](https://www.tritondatacenter.com/blog/550-regression-tests-in-4-minutes-with-joyent-manta): The Node team uses Manta to run a test case against all commits in a repository to find which one introduced a regression
 * [Kartlytics](http://kartlytics.com/): Mario Kart 64 analytics
 * [Image Manipulation and
-  Publishing](http://www.joyent.com/blog/manta-image-content-manipulation-and-publishing-example-part-1)
+  Publishing](http://www.tritondatacenter.com/blog/manta-image-content-manipulation-and-publishing-example-part-1)
   using the Getty Open Content Image Set
-* [Thoth](https://github.com/joyent/manta-thoth): Joyent stores and analyzes
+* [Thoth](https://github.com/TritonDataCenter/manta-thoth): stores and analyzes
   core dumps and crash dumps using Manta
 
 
@@ -72,8 +72,7 @@ Manta.
 To use Triton's object storage, you need a Triton Compute account.  If
 you don't already have an account, contact your administrator.
 
-Once you have signed up, you will need to add an SSH public key to your account. Joyent recommends using RSA keys, as the node-manta CLI programs will work with RSA keys both locally, and with the `ssh agent`. DSA keys will only work if the
-private key is on the same system as the CLI, and not password-protected.
+Once you have signed up, you will need to add an SSH public key to your account.
 
 <!--
 Standard Closing Paragraph
@@ -89,31 +88,25 @@ From this point on, this is the same exact material as inside the portal
 
 # Getting Started
 
-This tutorial assumes you've signed up for a Joyent account and have an RSA public SSH key added to your account. We will cover installing the node.js SDK and CLI, setting up your shell environment variables, and then working through examples of creating directories, objects, links and finally running compute jobs on your data.
+This tutorial assumes you've signed up for a Triton account and have a public SSH key added to your account. We will cover installing the node.js SDK and CLI, setting up your shell environment variables, and then working through examples of creating directories, objects, links and finally running compute jobs on your data.
 
 The CLI is the only tool used in these examples, and the instructions assume you're doing this from a Mac OS X, SmartOS, Linux or BSD system, and know how to use SSH and a terminal application such as Terminal.app. It helps to be familiar with basic Unix facilities like the shells, pipes, stdin, and stdout.
-
-## Using the Mac OS X installer
-
-If you do not have node.js installed you can use the complete installer for Mac. This installer installs node.js 0.10.x, npm, node-manta and smartdc.
-
-[OS X Installer](https://us-east.manta.joyent.com/manta/public/sdks/joyent-node-latest.pkg)
 
 ## If You Have node.js Installed
 
 If you have at least node.js 0.8.x installed (0.10.x is recommended) you can install the CLI and SDK from an npm package. All of the examples below work with both node.js 0.8.x and 0.10.x.
 
-    $ sudo npm install manta -g
+    sudo npm install manta -g
 
 Additionally, as the API is JSON-based, the examples will refer to the
 [json](https://github.com/trentm/json) tool, which helps put JSON output in a more human readable format. You can install from npm:
 
-    $ sudo npm install json -g
+    sudo npm install json -g
 
 Lastly, and while optional, if you want to use verbose debug logging with the
 SDK, you will want [bunyan](https://github.com/trentm/node-bunyan):
 
-    $ sudo npm install bunyan -g
+    sudo npm install bunyan -g
 
 ## Setting Up Your Environment
 
@@ -124,20 +117,20 @@ environment.  There are four environment variables that all command line tools l
 * `MANTA_URL` - The API endpoint
 * `MANTA_USER` - Your Triton Public Cloud account login name
 * `MANTA_SUBUSER` - A user who has limited access to your account.
-See [Role Based Access Control and Manta](rbac.html)
+  See [Role Based Access Control and Manta](rbac.html)
 * `MANTA_KEY_ID` - The fingerprint of your SSH key.
 
 Copy all of the text below, and paste it into your `~/.bash_profile` or `~/.bashrc`.
 
-	export MANTA_URL=https://us-east.manta.joyent.com
-	export MANTA_USER=$TRITON_CLOUD_USER_NAME
-	unset MANTA_SUBUSER # Unless you have subusers
+    export MANTA_URL=https://us-central.manta.mnx.io
+    export MANTA_USER=$TRITON_CLOUD_USER_NAME
+    unset MANTA_SUBUSER # Unless you have subusers
     export MANTA_KEY_ID=$(ssh-keygen -E md5 -l -f ~/.ssh/id_rsa.pub | awk '{print $2}' | tr -d '\n' | cut -d: -f 2-)
 
 An easy way to do this in Mac OS X, is to copy the text, then use the `pbpaste` command
 to add the text in the clipboard to your file. like this:
 
-    $ pbpaste >> ~/.bash_profile
+    pbpaste >> ~/.bash_profile
 
 Edit the `~/.bash_profile` or `~/.bashrc` file, replacing `$TRITON_CLOUD_USER_NAME` with your Triton Public Cloud username.
 
@@ -509,7 +502,7 @@ dynamically).
 
 ## Running Jobs Using Assets
 
-Although the compute facility provides a full Joyent SmartOS environment,
+Although the compute facility provides a full SmartOS environment,
 your jobs may require special software, additional configuration information, or
 any other static file that is useful. You can make these available as assets,
 which are objects that are copied into the compute environment when your
@@ -690,17 +683,17 @@ Now let's take it up one more level. You can see what's inside a simple node.js 
 
     $ mget /mantademo/public/manta-desc.txt
 
-      Joyent Manta Storage Service is a cloud service that offers both a highly
+      Manta Storage Service is a cloud service that offers both a highly
       available, highly durable object store and integrated compute. Application
       developers can store and process any amount of data at any time, from any
       location, without requiring additional compute resources.
 
     $ echo /mantademo/public/manta-desc.txt | mjob create -o -s /mantademo/public/capitalizer.js -m 'node /assets/mantademo/public/capitalizer.js'
       added 1 input to 2aa8a0a9-92e9-47f3-8b66-acf2a22d25a8
-      JOYENT MANTA STORAGE SERVICE IS A CLOUD SERVICE THAT OFFERS BOTH A HIGHLY
+      MANTA STORAGE SERVICE IS A CLOUD SERVICE THAT OFFERS BOTH A HIGHLY
       AVAILABLE, HIGHLY DURABLE OBJECT STORE AND INTEGRATED COMPUTE! APPLICATION
       DEVELOPERS CAN STORE AND PROCESS ANY AMOUNT OF DATA AT ANY TIME, FROM ANY
       LOCATION, WITHOUT REQUIRING ADDITIONAL COMPUTE RESOURCES!
 
 For more details compute jobs see the
-[Compute Jobs Reference documentation](http://apidocs.joyent.com/manta/jobs-reference.html), along with the [default installed software](compute-instance-software.html) and some of our [built-in compute utilities](compute-instance-utilities.html).
+[Compute Jobs Reference documentation](http://apidocs.tritondatacenter.com/manta/jobs-reference.html), along with the [default installed software](compute-instance-software.html) and some of our [built-in compute utilities](compute-instance-utilities.html).

--- a/docs/user-guide/jobs-reference.md
+++ b/docs/user-guide/jobs-reference.md
@@ -50,7 +50,7 @@ Several principles guide the design of the service:
 * Jobs execute quickly enough to iterate interactively and get results in real
   time.
 * Error cases are debuggable. In addition to providing stderr and core files,
-  the task execution environment is very close to a standard Joyent Instance,
+  the task execution environment is very close to a standard SmartOS Instance,
   which allows users to develop and debug jobs outside of the service if
   desired.
 * Transient failure of individual system components are not visible to users
@@ -188,7 +188,7 @@ tasks have no direct access to inputs as files, since the objects may not be
 stored locally, will not all be ready when the reduce task starts running, and
 are not assumed to fit on a single server.
 
-You'll notice that unlike other map-reduce services, Joyent Manta Storage
+You'll notice that unlike other map-reduce services, Triton Manta Storage
 Service tasks operate at the granularity of a complete object. If you want to
 process key-value pairs or something more structured, your script is responsible
 for parsing the input. Many Unix tools natively parse whitespace-delimited text
@@ -326,8 +326,8 @@ reducers in the next phase.  Also see documentation for "msplit".
 
 ## Compute instance images ("image" property)
 
-Compute instances are Joyent instances based on the manta-compute image. This
-image is essentially a [base image](https://docs.joyent.com/public-cloud/instances/infrastructure/images/smartos/base)
+Compute instances are SmartOS instances based on the manta-compute image. This
+image is essentially a [base image](https://docs.tritondatacenter.com/public-cloud/instances/infrastructure/images/smartos/base)
 with nearly all of the available packages preinstalled.
 
 By default, tasks run in compute instances with the most recently released image
@@ -336,7 +336,7 @@ semver-like value for the "image" property (e.g., "13.1.\*").  If that image is
 not available, tasks for that job will fail with an InvalidArgumentError.
 
 **You're strongly discouraged from depending on an exact version of the image,
-as Joyent may frequently release minor updates to existing images and retire
+as we may frequently release minor updates to existing images and retire
 older versions as long as the new one is backwards-compatible.**  Dependencies
 are intended so you can tie jobs to major releases, or "at least" a particular
 minor release.
@@ -404,7 +404,7 @@ Synopsis:
     mpipe [-p] [-r rIdx] [-H header:value ...] [manta path]
 
 Each invocation of mpipe reads data from stdin, potentially buffers it to local
-disk, and saves it as task output.  If a Joyent Manta Storage Service path is
+disk, and saves it as task output.  If a Manta Storage Service path is
 given, the output is saved to that path.  Otherwise, the object is stored with a
 unique name in the job's directory.  If -p is given, required parent directories
 are automatically created (like "mkdir -p").

--- a/docs/user-guide/mantanfs.md
+++ b/docs/user-guide/mantanfs.md
@@ -10,7 +10,7 @@ directories in your file system.
 
 `manta-nfs` implements a [NFS vers. 3](http://tools.ietf.org/html/rfc1813)
 server that uses
-[Joyent Manta](http://www.joyent.com/products/manta) as the backing store.
+[Triton Manta](http://www.tritondatacenter.com/products/manta) as the backing store.
 The server implements all NFS functionality, although some OS-level commands,
 such as `chmod`, will have no effect since Manta does not support that concept.
 The server is implemented in [node.js](http://nodejs.org/) and **requires**
@@ -18,7 +18,7 @@ v0.10.x.
 
 If node isn't installed on your machine,
 follow the instructions for
-[installing Manta](http://apidocs.joyent.com/manta/#getting-started).
+[installing Manta](http://apidocs.tritondatacenter.com/manta/#getting-started).
 
 
 # Quick Start
@@ -37,12 +37,12 @@ and install manta-nfs.
 
 
 Next, check that you have the
-[Manta environment variables set up](http://apidocs.joyent.com/manta/#setting-up-your-environment).
+[Manta environment variables set up](http://apidocs.tritondatacenter.com/manta/#setting-up-your-environment).
 
     $ env | grep MANTA
     MANTA_USER=mantauser
     MANTA_KEY_ID=3e:37:9b:11:a6:dc:21:be:1a:fd:95:b6:73:ea:42:9e
-    MANTA_URL=https://us-east.manta.joyent.com
+    MANTA_URL=https://us-central.manta.mnx.io
 
 Start the manta-nfs server. The server writes log output,
 so it's best to run it in its own terminal session.
@@ -151,7 +151,7 @@ to do this vary from operating system to operating system.
 
 You can find files mentioned in this section
 (launchd, SMF, rc)
-in the [manta-nfs repo on GitHub](https://github.com/joyent/manta-nfs).
+in the [manta-nfs repo on GitHub](https://github.com/TritonDataCenter/manta-nfs).
 
 
 ## Writing a Configuration File
@@ -167,7 +167,7 @@ The minimal configuration file is:
         "manta": {
             "keyFile": "/Users/mantauser/.ssh/id_rsa",
             "keyId": "03:71:24:1c:b6:64:51:9e:9d:6b:06:bf:4f:7c:19:dc",
-            "url": "https://us-east.manta.joyent.com",
+            "url": "https://us-central.manta.mnx.io",
             "user": "mantauser"
         }
     }
@@ -237,13 +237,13 @@ platforms. If you see the following, you know your mount code is incorrect.
     nfs mount: retrying: /home/foo.bar/mnt
 
 You will either need to run on a newer platform or you can use this
-[fixed NFS mount command](http://us-east.manta.joyent.com/jjelinek/public/mount)
+[fixed NFS mount command](http://us-central.manta.mnx.io/jjelinek/public/mount)
 explicitly. e.g.
 
     pfexec ./mount 127.0.0.1:/foo.bar/public /home/foo/mnt
 
 For unmounting, you can use this
-[fixed umount command](http://us-east.manta.joyent.com/jjelinek/public/umount)
+[fixed umount command](http://us-central.manta.mnx.io/jjelinek/public/umount)
 explicitly.
 
 On SmartOS the uid/gid for 'nobody' is 60001.
@@ -432,7 +432,7 @@ These next steps assume a default path for SSH keys. You can use other paths, bu
 * Append your Manta variable exports to `/root/.bashrc`, for example:
 
     ```
-    export MANTA_URL=https://us-east.manta.joyent.com
+    export MANTA_URL=https://us-central.manta.mnx.io
     export MANTA_USER=john.smith
     export MANTA_KEY_ID=b9:71:88:f4:c1:62:cf:b4:7c:cc:3b:00:d7:ff:21:46
     ```

--- a/docs/user-guide/mpu-reference.md
+++ b/docs/user-guide/mpu-reference.md
@@ -10,6 +10,7 @@ markdown2extras: wiki-tables, code-friendly
 
 <!--
     Copyright (c) 2018, Joyent, Inc.
+    Copyright 2023 MNX Cloud, Inc.
 -->
 
 # Multipart Uploads Reference
@@ -196,7 +197,7 @@ they are within the system-wide grace period for garbage collection.
 # Multipart Upload System Architecture
 
 This section describes some of the design principles that guide the operation of
-the Joyent Manta Multipart Upload Service.
+the Manta Multipart Upload Service.
 
 ## Guiding Principles
 

--- a/docs/user-guide/rbac.md
+++ b/docs/user-guide/rbac.md
@@ -72,8 +72,8 @@ To allow the access to a specific resource,
 you also need to associate, or tag, the resource with a role and add
 authorized users as members of the role. You can tag or untag roles
 for a resource by updating the 'role-tag' attribute value in the
-object metadata. See the [mchmod](https://apidocs.joyent.com/manta/mchmod.html)
-or [mchattr](https://apidocs.joyent.com/manta/mchattr.html) CLI reference for
+object metadata. See the [mchmod](https://apidocs.tritondatacenter.com/manta/mchmod.html)
+or [mchattr](https://apidocs.tritondatacenter.com/manta/mchattr.html) CLI reference for
 an example of updating object role tags or updating metadata in general.
 
 Roles can be tagged to directories as well (the only exception is the root
@@ -101,11 +101,11 @@ The account owner always has complete access to every resource in the account.
 
 # Learning More About Access Control
 
-To learn more see the main [RBAC documentation](https://docs.joyent.com/jpc/rbac).
+To learn more see the main [RBAC documentation](https://docs.tritondatacenter.com/jpc/rbac).
 
 If you want a quick walkthrough of how access control works with Manta,
-see [Getting Started With Access Control](https://docs.joyent.com/jpc/rbac/quickstart).
+see [Getting Started With Access Control](https://docs.tritondatacenter.com/jpc/rbac/quickstart).
 
 If you are already familiar with the key RBAC concepts, you can review the
-complete list of [Manta Actions](https://docs.joyent.com/public-cloud/rbac/rules#manta-actions)
+complete list of [Manta Actions](https://docs.tritondatacenter.com/public-cloud/rbac/rules#manta-actions)
 and start defining the rules for your RBAC policies.

--- a/docs/user-guide/sdks.md
+++ b/docs/user-guide/sdks.md
@@ -5,33 +5,33 @@ markdown2extras: wiki-tables, code-friendly
 
 # SDKs and CLI Tools
 
-The Joyent Manta Storage Service uses a REST API to read, write, and delete objects
+The Manta Storage Service uses a REST API to read, write, and delete objects
 and to create jobs to process them.
 
-Joyent provides several Software Development Kits so that you can use Joyent Manta in
+There are several Software Development Kits so that you can use Manta in
 a language and framework that you already know. Some of these SDKs provide
 Command Line Interface (CLI) tools to help you learn the system.
 
 
 # Node.js SDK and CLI
 
-The Node.js SDK was used to develop and to test the Joyent Manta Storage Service.
-It is the most robust SDK available for Joyent Manta.
+The Node.js SDK was used to develop and to test the Manta Storage Service.
+It is the most robust SDK available for Manta.
 
 The Node.js SDK includes a Command Line Interface that provides several
-tools that let you work with Joyent Manta much as you would work with a Unix system.
+tools that let you work with Manta much as you would work with a Unix system.
 We use this CLI for our [Getting Started](index.html) tutorial.
 
 The documentation for Node.js SDK is [here](nodesdk.html).
 
 
-You can find the Node.js SDK at [https://github.com/joyent/node-manta](https://github.com/joyent/node-manta).
+You can find the Node.js SDK at [https://github.com/TritonDataCenter/node-manta](https://github.com/TritonDataCenter/node-manta).
 
 
-# Python SDK and Joyent Manta Shell
+# Python SDK and Manta Shell
 
 The Python SDK is a community-maintained package for Manta, providing
-a "manta" package and `mantash`, a shell that lets you work with Joyent Manta in
+a "manta" package and `mantash`, a shell that lets you work with Manta in
 a bash-like environment.
 
     # Mantash single commands can be run like:
@@ -50,22 +50,22 @@ a bash-like environment.
     three
     four
 
-You can find the Python SDK at [https://github.com/joyent/python-manta](https://github.com/joyent/python-manta).
+You can find the Python SDK at [https://github.com/TritonDataCenter/python-manta](https://github.com/TritonDataCenter/python-manta).
 
 
 # Ruby SDK
 
-The Ruby SDK is a client for communicating with Joyent Manta.
+The Ruby SDK is a client for communicating with Manta.
 It is effectively an HTTP(S) wrapper which handles required HTTP headers and performs some sanity checks.
-The Ruby SDK seeks to expose all of Joyent Manta's features in a thin low-abstraction client.
+The Ruby SDK seeks to expose all of Manta's features in a thin low-abstraction client.
 
 
-You can find the Ruby SDK at [https://github.com/joyent/ruby-manta](https://github.com/joyent/ruby-manta).
+You can find the Ruby SDK at [https://github.com/TritonDataCenter/ruby-manta](https://github.com/TritonDataCenter/ruby-manta).
 
 # mantaRSDK
 
 The R SDK is an interactive client in the form of an R package,
-that exposes all of Joyent Manta's features, and supports R on Unix,
+that exposes all of Manta's features, and supports R on Unix,
 Linux and Windows.
 
 Manta HTTPS authentication uses OpenSSL,
@@ -76,11 +76,11 @@ Code example sessions are in the package R help,
 and Installation instructions on the GitHub README.md file.
 
 You can find the mantaRSDK at
-[https://github.com/joyent/mantaRSDK](https://github.com/joyent/mantaRSDK)
-and Rbunyan at [https://github.com/joyent/Rbunyan](https://github.com/joyent/Rbunyan).
+[https://github.com/TritonDataCenter/mantaRSDK](https://github.com/TritonDataCenter/mantaRSDK)
+and Rbunyan at [https://github.com/TritonDataCenter/Rbunyan](https://github.com/TritonDataCenter/Rbunyan).
 
 To learn more about mantaRSDK see
-[R Users, Meet Joyent Manta; Manta Users, Meet R](http://www.joyent.com/blog/r-users-meet-joyent-manta-manta-users-meet-r).
+[R Users, Meet Manta; Manta Users, Meet R](http://www.tritondatacenter.com/blog/r-users-meet-joyent-manta-manta-users-meet-r).
 
 
 # Java SDK
@@ -99,7 +99,7 @@ it add the following to your project's pom.xml:
         <version>LATEST</version>
     </dependency>
 
-You can find the source for Java SDK at [https://github.com/joyent/java-manta](https://github.com/joyent/java-manta).
+You can find the source for Java SDK at [https://github.com/TritonDataCenter/java-manta](https://github.com/TritonDataCenter/java-manta).
 
 
 # Hadoop FileSystem Driver
@@ -110,8 +110,8 @@ are dependent upon community involvement. The driver is available as a
 stand-alone jar file that can be dropped into a Hadoop or Apache Drill
 installation.
 
-You can download the jar directory from the [releases page](https://github.com/joyent/hadoop-manta/releases)
-on the [project's github page](https://github.com/joyent/hadoop-manta)
+You can download the jar directory from the [releases page](https://github.com/TritonDataCenter/hadoop-manta/releases)
+on the [project's github page](https://github.com/TritonDataCenter/hadoop-manta)
 or directly from Maven Central.
 
 
@@ -126,7 +126,7 @@ and can be installed using [Composer](https://getcomposer.org/):
 
 It has been tested in PHP 5.6, PHP 7.0 and HHVM.
 
-You can find the source for PHP SDK at [https://github.com/joyent/php-manta](https://github.com/joyent/php-manta).
+You can find the source for PHP SDK at [https://github.com/TritonDataCenter/php-manta](https://github.com/TritonDataCenter/php-manta).
 
 
 # Perl Module
@@ -136,7 +136,7 @@ a community driven module, so updates to it are dependent upon community
 involvement.
 The module is available on [CPAN](http://search.cpan.org/~andrewh/Manta-Client/).
 
-You can find the source for the Perl module at [https://github.com/joyent/Manta-Client](https://github.com/joyent/Manta-Client).   
+You can find the source for the Perl module at [https://github.com/TritonDataCenter/Manta-Client](https://github.com/TritonDataCenter/Manta-Client).
 
 
 # Golang SDK
@@ -145,7 +145,7 @@ The Go SDK for Manta is currently in active development. It is a combination SDK
 that provides support for Triton CloudAPI operations in addition to Manta API
 operations.
 
-You can find the source for the Go Manta SDK at [https://github.com/joyent/triton-go](https://github.com/joyent/triton-go).
+You can find the source for the Go Manta SDK at [https://github.com/TritonDataCenter/triton-go](https://github.com/TritonDataCenter/triton-go).
 
 
 # Erlang SDK
@@ -153,4 +153,4 @@ You can find the source for the Go Manta SDK at [https://github.com/joyent/trito
 The Erlang SDK for Manta is community-maintained SDK that has support for most
 file operations and jobs.
 
-You can find the source for the Erlang SDK at [https://github.com/joyent/erlang-manta](https://github.com/joyent/erlang-manta).
+You can find the source for the Erlang SDK at [https://github.com/TritonDataCenter/erlang-manta](https://github.com/TritonDataCenter/erlang-manta).

--- a/docs/user-guide/storage-reference.md
+++ b/docs/user-guide/storage-reference.md
@@ -5,7 +5,7 @@ markdown2extras: wiki-tables, code-friendly
 
 # Object Storage Reference
 
-The Joyent Manta Storage Service uses a REST API to read, write, and delete objects.
+The Manta Storage Service uses a REST API to read, write, and delete objects.
 This document assumes that you are familiar with HTTP-based REST systems, including
 HTTP requests, responses, status codes, and headers.
 
@@ -36,7 +36,7 @@ the storage service. The data portion is opaque. The metadata is a set of
 
 # Objects
 
-Objects are the primary entity you store in Joyent Manta Storage Service.
+Objects are the primary entity you store in Manta Storage Service.
 Objects can be of any size, including zero bytes.
 Objects consist of your raw, uninterpreted data,
 as well as the metadata (HTTP headers) returned when you retrieve an object.
@@ -302,7 +302,7 @@ There is no way to add additional metadata.
 # Storage System Architecture
 
 This section describes some of the design principles that guide the
-operation of the Joyent Manta Storage System.
+operation of the Manta Storage System.
 
 ## Guiding Principles
 
@@ -327,7 +327,7 @@ Several principles guide the design of the service:
 
 ## System scale
 
-Joyent Manta Storage Service is designed to support an arbitrarily large number of objects and an
+Manta Storage Service is designed to support an arbitrarily large number of objects and an
 arbitrarily large number of directories. However, it bounds the number of
 objects in a single directory so that list operations can be performed
 efficiently.

--- a/tools/jr-manifest.json
+++ b/tools/jr-manifest.json
@@ -2,7 +2,7 @@
     "jrVersion": 1,
     "description": "Manta public repositories",
     "repoCandidateSearch": {
-        "description": "public github.com/joyent repos directly relevant to development of Joyent Manta",
+        "description": "public github.com/TritonDataCenter repos directly relevant to development of Joyent Manta",
         "type": "public",
         "includeArchived": false
     },
@@ -30,7 +30,7 @@
         {
             "name": "mantav1",
             "type": "boolean",
-            "description": "Repositories are related to mantav1. See https://github.com/joyent/manta/blob/master/docs/mantav2.md"
+            "description": "Repositories are related to mantav1. See https://github.com/TritonDataCenter/manta/blob/master/docs/mantav2.md"
         },
         {
             "name": "mantav1branch",


### PR DESCRIPTION
This PR is against the `mantav1` branch, because that's what's used to generate content for https://apidocs.tritondatacenter.com.